### PR TITLE
Improve Aquarite entry lifecycle management

### DIFF
--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -1,14 +1,15 @@
-import logging
 import asyncio
+import contextlib
+import logging
 
-from homeassistant.core import HomeAssistant
+from homeassistant.components import binary_sensor, device_tracker, light, number, select, sensor, switch
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.components import binary_sensor, light, switch, sensor, select, number, device_tracker
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
 from .application_credentials import IdentityToolkitAuth
 from .aquarite import Aquarite
+from .const import DOMAIN
 from .coordinator import AquariteDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,6 +22,8 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Aquarite from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
     try:
         # Get user configuration from the entry
         user_config = entry.data
@@ -38,24 +41,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         # Initialize the coordinator with the API client
         coordinator = AquariteDataUpdateCoordinator(hass, auth, api)
         coordinator.set_pool_id(user_config["pool_id"])
+        auth.set_coordinator(coordinator)
         
         # Fetch initial pool data
         coordinator.data = await api.fetch_pool_data(user_config["pool_id"])
         await coordinator.subscribe()
 
-        # Store the coordinator and aiohttp session in Home Assistant's data
-        hass.data[DOMAIN]["coordinator"] = coordinator
-        hass.data[DOMAIN]["aiohttp_session"] = aiohttp_session
-
         # Start the token refresh routine
-        asyncio.create_task(auth.start_token_refresh_routine(coordinator))
+        refresh_task = hass.async_create_task(auth.start_token_refresh_routine(coordinator))
+
+        # Store the coordinator and aiohttp session in Home Assistant's data per entry
+        hass.data[DOMAIN][entry.entry_id] = {
+            "coordinator": coordinator,
+            "aiohttp_session": aiohttp_session,
+            "auth": auth,
+            "token_task": refresh_task,
+        }
 
         # Forward the entry setups for the defined platforms
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
         async def handle_sync_time(call):
             await coordinator.set_pool_time_to_now()
-        hass.services.async_register(DOMAIN, "sync_pool_time", handle_sync_time)
+
+        if not hass.services.has_service(DOMAIN, "sync_pool_time"):
+            hass.services.async_register(DOMAIN, "sync_pool_time", handle_sync_time)
 
         return True
 
@@ -66,17 +76,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload Aquarite config entry."""
     try:
-        # Retrieve and close the coordinator and aiohttp session
-        coordinator = hass.data[DOMAIN].get("coordinator")
+        entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+        if not entry_data:
+            _LOGGER.error("No entry data found for unload.")
+            return False
+
+        coordinator: AquariteDataUpdateCoordinator = entry_data.get("coordinator")
+        token_task: asyncio.Task | None = entry_data.get("token_task")
+
+        if token_task:
+            token_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await token_task
+
         if coordinator:
+            await coordinator.unsubscribe()
             await coordinator.auth.close()
-        
-        aiohttp_session = hass.data[DOMAIN].get("aiohttp_session")
-        if aiohttp_session:
-            await aiohttp_session.close()
 
         # Unload the platforms associated with this entry
-        return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+        unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+        if unloaded:
+            hass.data[DOMAIN].pop(entry.entry_id, None)
+            if not hass.data[DOMAIN]:
+                hass.data.pop(DOMAIN)
+
+        return unloaded
     except Exception as e:
         _LOGGER.error(f"Error unloading entry {entry.entry_id}: {e}")
         return False

--- a/custom_components/aquarite/application_credentials.py
+++ b/custom_components/aquarite/application_credentials.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from google.oauth2.credentials import Credentials
 from google.cloud.firestore_v1 import Client as FirestoreClient
 
-from .const import DOMAIN, API_KEY, BASE_URL, TOKEN_URL
+from .const import API_KEY, BASE_URL, TOKEN_URL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,6 +30,12 @@ class IdentityToolkitAuth:
         self.credentials = None
         self.client = None
         self.session = async_get_clientsession(hass)
+        self.coordinator = None
+
+    def set_coordinator(self, coordinator) -> None:
+        """Attach the coordinator to allow token refresh callbacks."""
+
+        self.coordinator = coordinator
 
     async def close(self):
         """Close the aiohttp session."""
@@ -96,8 +102,8 @@ class IdentityToolkitAuth:
         """Get the current client, refreshing if necessary."""
         if self.expiry and datetime.datetime.now() >= (self.expiry - datetime.timedelta(minutes=5)):
             await self.refresh_token()
-            coordinator = self.hass.data[DOMAIN].get("coordinator")
-            await coordinator.refresh_subscription()
+            if self.coordinator:
+                await self.coordinator.refresh_subscription()
         return self.client
 
     async def start_token_refresh_routine(self, coordinator):


### PR DESCRIPTION
## Summary
- store Aquarite entry data per config entry and guard service registration
- attach the coordinator to the auth helper so refreshes update subscriptions
- cancel refresh routines, unsubscribe, and clean data when unloading entries

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0de54628832c84f7a29645136039)