### PR TITLE
Avoid closing shared Home Assistant client session

### DIFF
--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -66,15 +66,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload Aquarite config entry."""
     try:
-        # Retrieve and close the coordinator and aiohttp session
-        coordinator = hass.data[DOMAIN].get("coordinator")
-        if coordinator:
-            await coordinator.auth.close()
-        
-        aiohttp_session = hass.data[DOMAIN].get("aiohttp_session")
-        if aiohttp_session:
-            await aiohttp_session.close()
-
         # Unload the platforms associated with this entry
         return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     except Exception as e:

--- a/custom_components/aquarite/application_credentials.py
+++ b/custom_components/aquarite/application_credentials.py
@@ -31,10 +31,6 @@ class IdentityToolkitAuth:
         self.client = None
         self.session = async_get_clientsession(hass)
 
-    async def close(self):
-        """Close the aiohttp session."""
-        await self.session.close()
-
     async def authenticate(self):
         await self.signin()
         return {


### PR DESCRIPTION
## Summary
- stop closing the shared aiohttp client session created by Home Assistant helpers
- remove unused coordinator cleanup during integration unload since no cleanup is required

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0f0753ec832c914b32657f77eb20)