### PR TITLE
Add shared Aquarite entity base class

### DIFF
--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -6,9 +6,9 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from .entity import AquariteEntity
 
-from .const import BRAND, DOMAIN, MODEL, PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX
+from .const import DOMAIN, PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX
 
 
 PROBLEM_VALUE_PATHS = {
@@ -121,7 +121,7 @@ async def async_setup_entry(
     return True
 
 
-class AquariteBinarySensorEntity(CoordinatorEntity, BinarySensorEntity):
+class AquariteBinarySensorEntity(AquariteEntity, BinarySensorEntity):
     """Aquarite Binary Sensor Entity such as flow sensors FL1 & FL2."""
 
     def __init__(
@@ -134,14 +134,10 @@ class AquariteBinarySensorEntity(CoordinatorEntity, BinarySensorEntity):
     ) -> None:
         """Initialize an Aquarite Binary Sensor Entity."""
 
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id
-        self._pool_name = pool_name
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=config.name)
         self._value_path = config.value_path
-        self._unique_id = f"{self._pool_id}-{config.name}"
         self._device_class = config.device_class
-        self._attr_name = f"{self._pool_name}_{config.name}"
+        self._attr_unique_id = self.build_unique_id(config.name)
 
     @property
     def device_class(self):
@@ -161,34 +157,14 @@ class AquariteBinarySensorEntity(CoordinatorEntity, BinarySensorEntity):
         """Return true if the device is on."""
         return bool(self._dataservice.get_value(self._value_path))
 
-    @property
-    def device_info(self):
-        """Return the device info."""
 
-        return {
-            "identifiers": {(DOMAIN, self._pool_id)},
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
-
-    @property
-    def unique_id(self):
-        """The unique id of the sensor."""
-        return self._unique_id
-
-
-class AquariteBinarySensorTankEntity(CoordinatorEntity, BinarySensorEntity):
+class AquariteBinarySensorTankEntity(AquariteEntity, BinarySensorEntity):
     """Aquarite Binary Sensor Entity Tank."""
 
     def __init__(self, hass: HomeAssistant, dataservice, name, pool_id, pool_name) -> None:
         """Initialize an Aquarite Binary Sensor Entity."""
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
-        self._unique_id = f"{self._pool_id}-{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def device_class(self):
@@ -201,17 +177,4 @@ class AquariteBinarySensorTankEntity(CoordinatorEntity, BinarySensorEntity):
 
         return any(self._dataservice.get_value(module) for module in TANK_MODULE_PATHS)
 
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "identifiers": {(DOMAIN, self._pool_id)},
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
-
-    @property
-    def unique_id(self):
-        """The unique id of the sensor."""
-        return self._unique_id
+    

--- a/custom_components/aquarite/entity.py
+++ b/custom_components/aquarite/entity.py
@@ -1,0 +1,33 @@
+"""Shared base entity helpers for Aquarite."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import BRAND, DOMAIN, MODEL
+
+
+class AquariteEntity(CoordinatorEntity):
+    """Base entity class for Aquarite platforms."""
+
+    def __init__(self, dataservice, pool_id: str, pool_name: str, *, name_suffix: str | None = None, full_name: str | None = None) -> None:
+        super().__init__(dataservice)
+        self._dataservice = dataservice
+        self._pool_id = pool_id
+        self._pool_name = pool_name
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, pool_id)},
+            "name": pool_name,
+            "manufacturer": BRAND,
+            "model": MODEL,
+        }
+
+        if full_name:
+            self._attr_name = full_name
+        elif name_suffix:
+            self._attr_name = f"{pool_name}_{name_suffix}"
+
+    def build_unique_id(self, suffix: str, *, delimiter: str = "-") -> str:
+        """Return a consistent unique ID for the entity."""
+
+        return f"{self._pool_id}{delimiter}{suffix}"

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -2,9 +2,9 @@
 
 from homeassistant.components.light import LightEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, BRAND, MODEL
+from .entity import AquariteEntity
+from .const import DOMAIN
 
 async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> bool:
 
@@ -24,32 +24,13 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> b
 
     return True
 
-class AquariteLightEntity(CoordinatorEntity, LightEntity):
+class AquariteLightEntity(AquariteEntity, LightEntity):
 
     def __init__(self, hass: HomeAssistant, dataservice, pool_id, pool_name, name, value_path) -> None:
 
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
-        self._unique_id = f"{self._pool_id}{name}"
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "identifiers": {(DOMAIN, self._pool_id)},
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
-
-    @property
-    def unique_id(self):
-        """The unique id of the sensor."""
-        return self._unique_id
+        self._attr_unique_id = self.build_unique_id(name, delimiter="")
 
     @property
     def color_mode(self):

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -2,9 +2,9 @@
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, BRAND, MODEL
+from .entity import AquariteEntity
+from .const import DOMAIN
 
 import logging
 _LOGGER = logging.getLogger(__name__)
@@ -30,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> b
     
     return True
 
-class AquariteNumberEntity(CoordinatorEntity, NumberEntity):
+class AquariteNumberEntity(AquariteEntity, NumberEntity):
 
     SCALE_MAP = {
         "modules.ph.status.low_value": 100,
@@ -46,32 +46,13 @@ class AquariteNumberEntity(CoordinatorEntity, NumberEntity):
     }
 
     def __init__(self, hass: HomeAssistant, dataservice, pool_id, pool_name, value_min, value_max, name, value_path):
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id
-        self._pool_name = pool_name
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._attr_native_min_value = value_min
         self._attr_native_max_value = value_max
         self._attr_native_step = 0.01
-        self._attr_name = f"{self._pool_name}_{name}"
         self._value_path = value_path
-        self._unique_id = f"{self._pool_id}-{name}"
+        self._attr_unique_id = self.build_unique_id(name)
         self._attr_unit_of_measurement = self.UNIT_MAP.get(value_path)
-
-    @property
-    def unique_id(self):
-        """The unique id of the number."""
-        return self._unique_id
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "identifiers": {(DOMAIN, self._pool_id)},
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
 
     @property
     def native_value(self):

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -2,9 +2,9 @@
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, BRAND, MODEL
+from .entity import AquariteEntity
+from .const import DOMAIN
 
 async def async_setup_entry(hass : HomeAssistant, entry, async_add_entities) -> bool:
     """Set up a config entry."""
@@ -25,35 +25,14 @@ async def async_setup_entry(hass : HomeAssistant, entry, async_add_entities) -> 
 
     return True
 
-class AquaritePumpModeEntity(CoordinatorEntity, SelectEntity):
+class AquaritePumpModeEntity(AquariteEntity, SelectEntity):
 
     def __init__(self, hass : HomeAssistant, dataservice, pool_id, pool_name, name, value_path) -> None:
 
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
-        self._unique_id = dataservice.get_value("id") + name
+        self._attr_unique_id = self.build_unique_id(name, delimiter="")
         self._allowed_values = ["Manual", "Auto", "Heat", "Smart", "Intel"]
-    
-    @property
-    def unique_id(self):
-        """The unique id of the sensor."""
-        return self._unique_id
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "identifiers": {
-                (DOMAIN, self._pool_id)
-            },
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
 
     @property
     def options(self) -> list[str]:
@@ -68,36 +47,14 @@ class AquaritePumpModeEntity(CoordinatorEntity, SelectEntity):
         """Set pump mode"""
         await self._dataservice.api.set_value(self._pool_id, self._value_path, self._allowed_values.index(option))
 
-class AquaritePumpSpeedEntity(CoordinatorEntity, SelectEntity):
+class AquaritePumpSpeedEntity(AquariteEntity, SelectEntity):
 
     def __init__(self, hass : HomeAssistant, dataservice, pool_id, pool_name, name, value_path) -> None:
         """Initialize a Aquarite Select Entity."""
-        super().__init__(dataservice)
-        """ self._attr_device_info =  """
-        self._dataservice = dataservice
-        self._pool_id = pool_id
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
-        self._unique_id = dataservice.get_value("id") + name
+        self._attr_unique_id = self.build_unique_id(name, delimiter="")
         self._allowed_values = ["Slow", "Medium", "High"]
-
-    @property
-    def unique_id(self):
-        """The unique id of the sensor."""
-        return self._unique_id
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "identifiers": {
-                (DOMAIN, self._pool_id)
-            },
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
 
     @property
     def options(self) -> list[str]:

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -3,12 +3,11 @@
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.const import PERCENTAGE, UnitOfElectricPotential, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .entity import AquariteEntity
 
 from .const import (
     DOMAIN,
-    BRAND,
-    MODEL,
     PATH_HASCD,
     PATH_HASCL,
     PATH_HASHIDRO,
@@ -185,7 +184,7 @@ async def async_setup_entry(hass : HomeAssistant, entry, async_add_entities) -> 
 
     return True
 
-class AquariteSpeedLabelSensorEntity(CoordinatorEntity, SensorEntity):
+class AquariteSpeedLabelSensorEntity(AquariteEntity, SensorEntity):
     _attr_icon = "mdi:speedometer"
 
     SPEED_LABELS = {
@@ -195,26 +194,9 @@ class AquariteSpeedLabelSensorEntity(CoordinatorEntity, SensorEntity):
     }
 
     def __init__(self, hass, dataservice, pool_id, pool_name, name, value_path):
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
-        self._unique_id = dataservice.get_value("id") + "-" + name
-
-    @property
-    def unique_id(self):
-        return self._unique_id
-
-    @property
-    def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._pool_id)},
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self):
@@ -225,29 +207,12 @@ class AquariteSpeedLabelSensorEntity(CoordinatorEntity, SensorEntity):
             int_value = -1
         return self.SPEED_LABELS.get(int_value, "Unknown")
 
-class AquariteIntervalTimeSensorEntity(CoordinatorEntity, SensorEntity):
+class AquariteIntervalTimeSensorEntity(AquariteEntity, SensorEntity):
     def __init__(self, hass, dataservice, pool_id, pool_name, name, value_path, icon=None):
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
         self._attr_icon = icon
-        self._unique_id = dataservice.get_value("id") + "-" + name
-
-    @property
-    def unique_id(self):
-        return self._unique_id
-
-    @property
-    def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._pool_id)},
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self):
@@ -262,37 +227,16 @@ class AquariteIntervalTimeSensorEntity(CoordinatorEntity, SensorEntity):
             days_later = hours // 24
             return f"{display_hours:02d}:{minutes:02d} (+{days_later}d)"
 
-class AquariteTemperatureSensorEntity(CoordinatorEntity, SensorEntity):
+class AquariteTemperatureSensorEntity(AquariteEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
     def __init__(self, hass : HomeAssistant, dataservice, pool_id, pool_name, name, value_path) -> None:
 
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id 
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
-        self._unique_id = dataservice.get_value("id") + "-" + name
-
-    @property
-    def unique_id(self):
-        """The unique id of the sensor."""
-        return self._unique_id
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "identifiers": {
-                (DOMAIN, self._pool_id)
-            },
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self):
@@ -304,37 +248,16 @@ class AquariteTemperatureSensorEntity(CoordinatorEntity, SensorEntity):
         """Return the unit of measurement."""
         return UnitOfTemperature.CELSIUS
 
-class AquariteValueSensorEntity(CoordinatorEntity, SensorEntity):
+class AquariteValueSensorEntity(AquariteEntity, SensorEntity):
 
     def __init__(self, hass : HomeAssistant, dataservice, pool_id, pool_name, name, value_path, device_class:SensorDeviceClass = None, native_unit_of_measurement:str = None, icon:str = None) -> None:
 
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id 
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
         self._attr_device_class = device_class
         self._attr_native_unit_of_measurement = native_unit_of_measurement
         self._attr_icon = icon
-        self._unique_id = dataservice.get_value("id") + "-" + name
-
-    @property
-    def unique_id(self):
-        """The unique id of the sensor."""
-        return self._unique_id
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "identifiers": {
-                (DOMAIN, self._pool_id)
-            },
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self):
@@ -342,37 +265,16 @@ class AquariteValueSensorEntity(CoordinatorEntity, SensorEntity):
         value = self._dataservice.get_value(self._value_path)
         return float(value) / 100
 
-class AquariteTimeSensorEntity(CoordinatorEntity, SensorEntity):
+class AquariteTimeSensorEntity(AquariteEntity, SensorEntity):
 
     def __init__(self, hass : HomeAssistant, dataservice, pool_id, pool_name, name, value_path, device_class:SensorDeviceClass = None, native_unit_of_measurement:str = None, icon:str = None) -> None:
 
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id 
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
         self._attr_device_class = device_class
         self._attr_native_unit_of_measurement = native_unit_of_measurement
         self._attr_icon = icon
-        self._unique_id = dataservice.get_value("id") + "-" + name
-
-    @property
-    def unique_id(self):
-        """The unique id of the sensor."""
-        return self._unique_id
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "identifiers": {
-                (DOMAIN, self._pool_id)
-            },
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self):
@@ -381,105 +283,44 @@ class AquariteTimeSensorEntity(CoordinatorEntity, SensorEntity):
         hours = minutes / 60 
         return hours
 
-class AquariteHydrolyserSensorEntity(CoordinatorEntity, SensorEntity):
+class AquariteHydrolyserSensorEntity(AquariteEntity, SensorEntity):
 
     _attr_icon = "mdi:gauge"
     _attr_native_unit_of_measurement = "gr/h"
 
     def __init__(self, hass : HomeAssistant, dataservice, pool_id, pool_name, name, value_path) -> None:
 
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id 
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
-        self._unique_id = dataservice.get_value("id") + "-" + name
-
-    @property
-    def unique_id(self):
-        """The unique id of the sensor."""
-        return self._unique_id
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "identifiers": {
-                (DOMAIN, self._pool_id)
-            },
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self) -> float:
         """Return value of sensor."""
         return float(self._dataservice.get_value(self._value_path)) / 10
 
-class AquariteRxValueSensorEntity(CoordinatorEntity, SensorEntity):
+class AquariteRxValueSensorEntity(AquariteEntity, SensorEntity):
 
     _attr_icon = "mdi:gauge"
     _attr_native_unit_of_measurement = UnitOfElectricPotential.MILLIVOLT
 
     def __init__(self, hass : HomeAssistant, dataservice, pool_id, pool_name, name, value_path) -> None:
 
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id 
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
-        self._unique_id = dataservice.get_value("id") + "-" + name
-
-    @property
-    def unique_id(self):
-        """The unique id of the sensor."""
-        return self._unique_id
-        
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "identifiers": {
-                (DOMAIN, self._pool_id)
-            },
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
+        self._attr_unique_id = self.build_unique_id(name)
     
     @property
     def native_value(self) -> int:
         """Return value of sensor."""
         return int(self._dataservice.get_value(self._value_path))
 
-class AquariteLocationSensorEntity(CoordinatorEntity, SensorEntity):
+class AquariteLocationSensorEntity(AquariteEntity, SensorEntity):
     def __init__(self, hass, dataservice, pool_id, pool_name, name, form_key, icon=None):
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id
-        self._pool_name = pool_name
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._form_key = form_key
-        self._attr_name = f"{self._pool_name}_{name}"
-        self._unique_id = dataservice.get_value("id") + "-" + name
         self._attr_icon = icon
-
-    @property
-    def unique_id(self):
-        return self._unique_id
-
-    @property
-    def device_info(self):
-        return {
-            "identifiers": {
-                (DOMAIN, self._pool_id)
-            },
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self):
@@ -488,27 +329,16 @@ class AquariteLocationSensorEntity(CoordinatorEntity, SensorEntity):
             return None
         return form.get(self._form_key)
 
-class AquaritePoolNameSensorEntity(CoordinatorEntity, SensorEntity):
+class AquaritePoolNameSensorEntity(AquariteEntity, SensorEntity):
     def __init__(self, hass, dataservice, pool_id):
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id
+        pool_name = dataservice.get_pool_name(pool_id)
+        super().__init__(dataservice, pool_id, pool_name, full_name=f"{pool_name} Name")
         self._unique_id = dataservice.get_value("id") + "-name"
-        self._attr_name = f"{dataservice.get_pool_name(pool_id)} Name"
         self._attr_icon = "mdi:pool"
 
     @property
     def unique_id(self):
         return self._unique_id
-
-    @property
-    def device_info(self):
-        return {
-            "identifiers": {(DOMAIN, self._pool_id)},
-            "name": self._attr_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
 
     @property
     def native_value(self):

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -1,9 +1,9 @@
 """Aquarite Switch entity."""
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, BRAND, MODEL
+from .entity import AquariteEntity
+from .const import DOMAIN
 
 async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> bool:
     """Set up a config entry."""
@@ -29,28 +29,14 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> b
 
     return True
 
-class AquariteSwitchEntity(CoordinatorEntity, SwitchEntity):
+class AquariteSwitchEntity(AquariteEntity, SwitchEntity):
     """Aquarite Switch Entity."""
 
     def __init__(self, hass: HomeAssistant, dataservice, pool_id, pool_name, name, value_path) -> None:
         """Initialize a Aquarite Switch Entity."""
-        super().__init__(dataservice)
-        self._dataservice = dataservice
-        self._pool_id = pool_id
-        self._pool_name = pool_name
-        self._attr_name = f"{self._pool_name}_{name}"
+        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
-        self._unique_id = f"{self._pool_id}{name}"
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "identifiers": {(DOMAIN, self._pool_id)},
-            "name": self._pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
+        self._attr_unique_id = self.build_unique_id(name, delimiter="")
 
     @property
     def extra_state_attributes(self) -> dict[str, str] | None:
@@ -84,7 +70,3 @@ class AquariteSwitchEntity(CoordinatorEntity, SwitchEntity):
         """Turn the entity off."""
         await self._dataservice.api.set_value(self._pool_id, self._value_path, 0)
 
-    @property
-    def unique_id(self):
-        """The unique id of the sensor."""
-        return self._unique_id


### PR DESCRIPTION
## Summary
- add a shared `AquariteEntity` base class consolidating device info and naming
- update Aquarite platforms to use the shared base and consistent unique IDs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c11bf5514832cb68d9990852bf618)