### PR TITLE
Improve Aquarite entity typing

### DIFF
--- a/custom_components/aquarite/entity.py
+++ b/custom_components/aquarite/entity.py
@@ -5,14 +5,25 @@ from __future__ import annotations
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import BRAND, DOMAIN, MODEL
+from .coordinator import AquariteDataUpdateCoordinator
 
 
-class AquariteEntity(CoordinatorEntity):
+class AquariteEntity(CoordinatorEntity[AquariteDataUpdateCoordinator]):
     """Base entity class for Aquarite platforms."""
 
-    def __init__(self, dataservice, pool_id: str, pool_name: str, *, name_suffix: str | None = None, full_name: str | None = None) -> None:
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        *,
+        name_suffix: str | None = None,
+        full_name: str | None = None,
+    ) -> None:
         super().__init__(dataservice)
-        self._dataservice = dataservice
+        self._dataservice: AquariteDataUpdateCoordinator = dataservice
         self._pool_id = pool_id
         self._pool_name = pool_name
         self._attr_device_info = {
@@ -26,6 +37,18 @@ class AquariteEntity(CoordinatorEntity):
             self._attr_name = full_name
         elif name_suffix:
             self._attr_name = f"{pool_name}_{name_suffix}"
+
+    @property
+    def pool_id(self) -> str:
+        """Return the pool ID for the entity."""
+
+        return self._pool_id
+
+    @property
+    def pool_name(self) -> str:
+        """Return the friendly pool name for the entity."""
+
+        return self._pool_name
 
     def build_unique_id(self, suffix: str, *, delimiter: str = "-") -> str:
         """Return a consistent unique ID for the entity."""


### PR DESCRIPTION
## Summary
- type the Aquarite base entity with the custom coordinator and mark entities as having explicit names
- expose helper properties for pool id and name to simplify downstream usage

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1544834c832ca54f6305a38069c6)