### PR TITLE
Refactor Aquarite select entities

### DIFF
--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -1,15 +1,23 @@
 """Aquarite Select entities."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
+
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
 
-from .entity import AquariteEntity
 from .const import DOMAIN
+from .entity import AquariteEntity
 
-async def async_setup_entry(hass : HomeAssistant, entry, async_add_entities) -> bool:
+PUMP_MODE_OPTIONS: tuple[str, ...] = ("Manual", "Auto", "Heat", "Smart", "Intel")
+PUMP_SPEED_OPTIONS: tuple[str, ...] = ("Slow", "Medium", "High")
+
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> bool:
     """Set up a config entry."""
     dataservice = hass.data[DOMAIN]["coordinator"]
-    
+
     if not dataservice:
         return False
 
@@ -17,55 +25,65 @@ async def async_setup_entry(hass : HomeAssistant, entry, async_add_entities) -> 
     pool_name = dataservice.get_pool_name(pool_id)
 
     entities = [
-        AquaritePumpModeEntity(hass, dataservice, pool_id, pool_name, "Pump Mode", "filtration.mode"),
-        AquaritePumpSpeedEntity(hass, dataservice, pool_id, pool_name, "Pump Speed", "filtration.manVel")
+        AquaritePumpModeEntity(dataservice, pool_id, pool_name, "Pump Mode", "filtration.mode"),
+        AquaritePumpSpeedEntity(dataservice, pool_id, pool_name, "Pump Speed", "filtration.manVel"),
     ]
 
     async_add_entities(entities)
 
     return True
 
-class AquaritePumpModeEntity(AquariteEntity, SelectEntity):
 
-    def __init__(self, hass : HomeAssistant, dataservice, pool_id, pool_name, name, value_path) -> None:
+class AquariteSelectEntity(AquariteEntity, SelectEntity):
+    """Shared functionality for Aquarite select entities."""
 
+    def __init__(
+        self,
+        dataservice,
+        pool_id,
+        pool_name,
+        name: str,
+        value_path: str,
+        allowed_values: Sequence[str],
+    ) -> None:
         super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
         self._value_path = value_path
+        self._allowed_values: tuple[str, ...] = tuple(allowed_values)
         self._attr_unique_id = self.build_unique_id(name, delimiter="")
-        self._allowed_values = ["Manual", "Auto", "Heat", "Smart", "Intel"]
+        self._attr_options = list(self._allowed_values)
 
     @property
-    def options(self) -> list[str]:
-        return list(self._allowed_values)
+    def current_option(self) -> str | None:
+        """Return the currently selected option, if available."""
 
-    @property
-    def current_option(self) -> str:
-        """Return current pump mode"""      
-        return self._allowed_values[self._dataservice.get_value(self._value_path)]
+        raw_value = self._dataservice.get_value(self._value_path)
 
-    async def async_select_option(self, option: str):
-        """Set pump mode"""
-        await self._dataservice.api.set_value(self._pool_id, self._value_path, self._allowed_values.index(option))
+        try:
+            return self._allowed_values[int(raw_value)]
+        except (TypeError, ValueError, IndexError):
+            return None
 
-class AquaritePumpSpeedEntity(AquariteEntity, SelectEntity):
+    async def async_select_option(self, option: str) -> None:
+        """Set the selected option."""
 
-    def __init__(self, hass : HomeAssistant, dataservice, pool_id, pool_name, name, value_path) -> None:
-        """Initialize a Aquarite Select Entity."""
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
-        self._value_path = value_path
-        self._attr_unique_id = self.build_unique_id(name, delimiter="")
-        self._allowed_values = ["Slow", "Medium", "High"]
+        if option not in self._allowed_values:
+            raise ValueError(f"Invalid option {option!r} for {self.name}")
 
-    @property
-    def options(self) -> list[str]:
-        return list(self._allowed_values)
+        await self._dataservice.api.set_value(
+            self._pool_id, self._value_path, self._allowed_values.index(option)
+        )
 
-    @property
-    def current_option(self) -> str:
-        """Return current pump speed"""      
-        return self._allowed_values[self._dataservice.get_value(self._value_path)]
 
-    async def async_select_option(self, option: str):
-        """Set pump speed"""
-        await self._dataservice.api.set_value(self._pool_id, self._value_path, self._allowed_values.index(option))
+class AquaritePumpModeEntity(AquariteSelectEntity):
+    """Select entity representing the pump mode."""
+
+    def __init__(self, dataservice, pool_id, pool_name, name, value_path) -> None:
+        super().__init__(dataservice, pool_id, pool_name, name, value_path, PUMP_MODE_OPTIONS)
+
+
+class AquaritePumpSpeedEntity(AquariteSelectEntity):
+    """Select entity representing the pump speed."""
+
+    def __init__(self, dataservice, pool_id, pool_name, name, value_path) -> None:
+        super().__init__(dataservice, pool_id, pool_name, name, value_path, PUMP_SPEED_OPTIONS)
 


### PR DESCRIPTION
## Summary
- refactor Aquarite select entities to share common setup and option handling
- validate selected options and guard against invalid indexes when reading values
- declare pump mode and speed options centrally and remove unused parameters

## Testing
- python -m compileall custom_components/aquarite

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c166498c8832cb63e6af8ac57fcb9)