### PR TITLE
Improve config flow strings

### DIFF
--- a/custom_components/aquarite/strings.json
+++ b/custom_components/aquarite/strings.json
@@ -11,18 +11,20 @@
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "The Hayward integration needs to re-authenticate your account"
+        "description": "Re-authenticate your Hayward account to continue."
       },
-      "location": {
+      "pool": {
         "data": {
-          "CONF_LOCATION_ID": "Pools:"
+          "pool_id": "Pools:"
         },
-        "description": "Please choose the pool for this HA",
-        "title": "Setup Pool"
+        "description": "Please choose the pool for this integration.",
+        "title": "Select Pool"
       }
     },
     "error": {
-      "auth_error": "Authorization failed, check username and password."
+      "auth_error": "Authorization failed, check username and password.",
+      "no_pools_found": "No pools found for your account.",
+      "unknown_error": "Unexpected error. Please try again."
     },
     "abort": {
       "reauth_successful": "New login info has been saved"


### PR DESCRIPTION
## Summary
- align config flow strings with the pool selection step
- clarify reauthentication messaging and error coverage in config strings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c16f8730c832cbf186e5f1e73f01f)