### PR TITLE
Fix Aquarite coordinator lookup and cleanup tasks

### DIFF
--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -42,6 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         coordinator = AquariteDataUpdateCoordinator(hass, auth, api)
         coordinator.set_pool_id(user_config["pool_id"])
         auth.set_coordinator(coordinator)
+        api.set_coordinator(coordinator)
         
         # Fetch initial pool data
         coordinator.data = await api.fetch_pool_data(user_config["pool_id"])
@@ -90,7 +91,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
                 await token_task
 
         if coordinator:
-            await coordinator.unsubscribe()
+            await coordinator.async_shutdown()
             await coordinator.auth.close()
 
         # Unload the platforms associated with this entry

--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -70,9 +70,11 @@ async def async_setup_entry(
 ) -> bool:
     """Set up a config entry."""
 
-    dataservice = hass.data[DOMAIN]["coordinator"]
-    if not dataservice:
+    entry_data = hass.data[DOMAIN].get(entry.entry_id)
+    if not entry_data:
         return False
+
+    dataservice = entry_data["coordinator"]
 
     pool_id = dataservice.get_value("id")
     pool_name = dataservice.get_pool_name(pool_id)

--- a/custom_components/aquarite/device_tracker.py
+++ b/custom_components/aquarite/device_tracker.py
@@ -17,7 +17,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up the pool location tracker."""
 
-    coordinator = hass.data[DOMAIN]["coordinator"]
+    entry_data = hass.data[DOMAIN].get(entry.entry_id)
+    if not entry_data:
+        return
+
+    coordinator = entry_data["coordinator"]
 
     pool_id = coordinator.get_value("id")
     pool_name = coordinator.get_pool_name(pool_id)

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -15,10 +15,11 @@ async def async_setup_entry(
 ) -> bool:
     """Set up the Aquarite light platform."""
 
-    dataservice = hass.data[DOMAIN]["coordinator"]
-
-    if not dataservice:
+    entry_data = hass.data[DOMAIN].get(entry.entry_id)
+    if not entry_data:
         return False
+
+    dataservice = entry_data["coordinator"]
 
     pool_id = dataservice.get_value("id")
     pool_name = dataservice.get_pool_name(pool_id)

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -21,10 +21,11 @@ async def async_setup_entry(
 ) -> bool:
     """Set up Aquarite number entities from a config entry."""
 
-    dataservice = hass.data[DOMAIN]["coordinator"]
-
-    if not dataservice:
+    entry_data = hass.data[DOMAIN].get(entry.entry_id)
+    if not entry_data:
         return False
+
+    dataservice = entry_data["coordinator"]
 
     pool_id = dataservice.get_value("id")
     pool_name = dataservice.get_pool_name(pool_id)

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
@@ -14,12 +15,15 @@ PUMP_MODE_OPTIONS: tuple[str, ...] = ("Manual", "Auto", "Heat", "Smart", "Intel"
 PUMP_SPEED_OPTIONS: tuple[str, ...] = ("Slow", "Medium", "High")
 
 
-async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> bool:
     """Set up a config entry."""
-    dataservice = hass.data[DOMAIN]["coordinator"]
-
-    if not dataservice:
+    entry_data = hass.data[DOMAIN].get(entry.entry_id)
+    if not entry_data:
         return False
+
+    dataservice = entry_data["coordinator"]
 
     pool_id = dataservice.get_value("id")
     pool_name = dataservice.get_pool_name(pool_id)

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -187,10 +187,11 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> bool:
-    dataservice = hass.data[DOMAIN]["coordinator"]
-
-    if not dataservice:
+    entry_data = hass.data[DOMAIN].get(entry.entry_id)
+    if not entry_data:
         return False
+
+    dataservice = entry_data["coordinator"]
 
     pool_id = dataservice.get_value("id")
     pool_name = dataservice.get_pool_name(pool_id)

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -1,5 +1,6 @@
 """Aquarite Switch entity."""
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
@@ -16,12 +17,15 @@ SWITCH_ENTITY_DEFINITIONS = (
     ("Filtration Status", "filtration.status"),
 )
 
-async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> bool:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> bool:
     """Set up a config entry."""
-    dataservice = hass.data[DOMAIN]["coordinator"]
-
-    if not dataservice:
+    entry_data = hass.data[DOMAIN].get(entry.entry_id)
+    if not entry_data:
         return False
+
+    dataservice = entry_data["coordinator"]
 
     pool_id = dataservice.get_value("id")
     pool_name = dataservice.get_pool_name(pool_id)


### PR DESCRIPTION
## Summary
- ensure each platform setup uses the config entry's stored coordinator and wire the API client to it
- add coordinator shutdown routine to cancel periodic polling/health tasks and unsubscribe watchers when unloading
- guard command payload building by requiring an attached coordinator reference

## Testing
- python -m compileall custom_components/aquarite

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1872e6b4832ca6e76c45b1a90389)