### PR TITLE
Fix Aquarite number step calculation

### DIFF
--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -112,7 +112,7 @@ class AquariteNumberEntity(AquariteEntity, NumberEntity):
         self._value_path = value_path
         self._attr_unique_id = self.build_unique_id(name)
         self._attr_unit_of_measurement = self.UNIT_MAP.get(value_path)
-        self._attr_native_step = self._calculate_step(value_path)
+        self._attr_native_step = self._get_scaled_step()
 
     @property
     def native_value(self):
@@ -136,7 +136,16 @@ class AquariteNumberEntity(AquariteEntity, NumberEntity):
         )
         self.async_write_ha_state()
 
-    def _calculate_step(self, value_path: str) -> float:
+    def _get_scaled_step(self) -> float:
         """Return a step value that matches the configured scale."""
-        scale = self.SCALE_MAP.get(value_path)
+        scale = self.SCALE_MAP.get(self._value_path)
         return 1 / scale if scale else 1.0
+
+    def _calculate_step(self, min_value: float, max_value: float) -> float:
+        """Return the step value advertised to Home Assistant."""
+
+        step = self._get_scaled_step()
+        if step:
+            return step
+
+        return super()._calculate_step(min_value, max_value)


### PR DESCRIPTION
## Summary
- ensure Aquarite number entity step calculation matches Home Assistant expectations
- derive scaled step values without breaking NumberEntity capability handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1c37d5f8832cae2f21219fa0fd3e)