### PR TITLE
Handle missing Firestore client and log update errors

### DIFF
--- a/custom_components/aquarite/application_credentials.py
+++ b/custom_components/aquarite/application_credentials.py
@@ -96,6 +96,10 @@ class IdentityToolkitAuth:
 
     async def get_client(self):
         """Get the current client, refreshing if necessary."""
+        if self.client is None:
+            _LOGGER.debug("Firestore client not initialized, performing authentication.")
+            await self.authenticate()
+
         if self.expiry and datetime.datetime.now() >= (self.expiry - datetime.timedelta(minutes=5)):
             await self.refresh_token()
             if self.coordinator:


### PR DESCRIPTION
## Summary
- ensure the Firestore client re-authenticates when it has not been initialized
- capture exceptions from snapshot update handling without throwing in the callback

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1d9e9008832cadd1cfa3f2d2db15)