### PR TITLE
Avoid duplicating pool name in entity IDs

### DIFF
--- a/custom_components/aquarite/entity.py
+++ b/custom_components/aquarite/entity.py
@@ -36,7 +36,10 @@ class AquariteEntity(CoordinatorEntity[AquariteDataUpdateCoordinator]):
         if full_name:
             self._attr_name = full_name
         elif name_suffix:
-            self._attr_name = f"{pool_name}_{name_suffix}"
+            # When ``_attr_has_entity_name`` is True, Home Assistant automatically
+            # prefixes the device name to the entity name. Provide only the suffix
+            # here to avoid duplicating the pool name in the generated entity ID.
+            self._attr_name = name_suffix
 
     @property
     def pool_id(self) -> str:


### PR DESCRIPTION
## Summary
- avoid duplicating the pool name when constructing entity names by relying on Home Assistant's entity name handling

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c220bc2d4832c846f376707723231)