### PR TITLE
Prevent Aquarite background tasks from blocking bootstrap

### DIFF
--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -49,7 +49,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         await coordinator.subscribe()
 
         # Start the token refresh routine
-        refresh_task = hass.async_create_task(auth.start_token_refresh_routine(coordinator))
+        refresh_task = hass.async_create_background_task(
+            auth.start_token_refresh_routine(coordinator),
+            name="Aquarite token refresh",
+        )
 
         # Store the coordinator and aiohttp session in Home Assistant's data per entry
         hass.data[DOMAIN][entry.entry_id] = {

--- a/custom_components/aquarite/application_credentials.py
+++ b/custom_components/aquarite/application_credentials.py
@@ -107,7 +107,7 @@ class IdentityToolkitAuth:
         return self.client
 
     async def start_token_refresh_routine(self, coordinator):
-        while True:
+        while not self.hass.is_stopping:
             try:
                 await self.ensure_active_token()
                 await asyncio.sleep(self.calculate_sleep_duration())


### PR DESCRIPTION
## Summary
- run Aquarite health check and polling loops as Home Assistant background tasks
- stop long-running polling and health check loops when Home Assistant is stopping
- start token refresh routine as a background task to avoid bootstrap tracking

## Testing
- python -m compileall custom_components/aquarite


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c4bb62358832ca72da41910c49a75)