### PR TITLE
Harden Aquarite authentication handling

### DIFF
--- a/custom_components/aquarite/config_flow.py
+++ b/custom_components/aquarite/config_flow.py
@@ -12,10 +12,15 @@ import homeassistant.helpers.config_validation as cv
 
 from .application_credentials import IdentityToolkitAuth, UnauthorizedException
 from .aquarite import Aquarite
-from .const import DOMAIN
+from .const import CONF_ORIGIN, CONF_REFERER, DOMAIN
 
 AUTH_SCHEMA = vol.Schema(
-    {vol.Required(CONF_USERNAME): cv.string, vol.Required(CONF_PASSWORD): cv.string}
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_REFERER): cv.string,
+        vol.Optional(CONF_ORIGIN): cv.string,
+    }
 )
 
 
@@ -36,6 +41,10 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_USERNAME: user_input[CONF_USERNAME],
                 CONF_PASSWORD: user_input[CONF_PASSWORD],
             }
+            if user_input.get(CONF_REFERER):
+                self.data[CONF_REFERER] = user_input[CONF_REFERER]
+            if user_input.get(CONF_ORIGIN):
+                self.data[CONF_ORIGIN] = user_input[CONF_ORIGIN]
             return await self.async_step_pool()
 
         schema = AUTH_SCHEMA
@@ -63,6 +72,10 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_PASSWORD: self.data[CONF_PASSWORD],
                 "pool_id": pool_id,
             }
+            if self.data.get(CONF_REFERER):
+                entry_data[CONF_REFERER] = self.data[CONF_REFERER]
+            if self.data.get(CONF_ORIGIN):
+                entry_data[CONF_ORIGIN] = self.data[CONF_ORIGIN]
 
             if self._reauth_entry:
                 self.hass.config_entries.async_update_entry(
@@ -83,7 +96,11 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             auth = IdentityToolkitAuth(
-                self.hass, self.data[CONF_USERNAME], self.data[CONF_PASSWORD]
+                self.hass,
+                self.data[CONF_USERNAME],
+                self.data[CONF_PASSWORD],
+                self.data.get(CONF_REFERER),
+                self.data.get(CONF_ORIGIN),
             )
             await auth.authenticate()
 

--- a/custom_components/aquarite/const.py
+++ b/custom_components/aquarite/const.py
@@ -3,6 +3,8 @@
 DOMAIN = "aquarite"
 BRAND = "Hayward"
 MODEL = "Aquarite"
+CONF_REFERER = "referer"
+CONF_ORIGIN = "origin"
 
 PATH_PREFIX = "main."
 PATH_HASCD = f"{PATH_PREFIX}hasCD"


### PR DESCRIPTION
### Motivation
- Avoid crashes from inconsistent token key casing by normalizing snake_case and camelCase responses from Google Identity Toolkit. 
- Support HTTP-referrer restricted API keys by allowing optional `Referer`/`Origin` headers and avoid leaking tokens in logs or exceptions. 
- Make token refresh and integration setup more robust by preserving refresh tokens when missing, validating expiry values, and propagating HA-specific setup errors.

### Description
- `custom_components/aquarite/application_credentials.py`: Added optional `referer` and `origin` parameters, a `_build_headers` helper to conditionally include `Referer`/`Origin`, `_normalize_tokens` to map `expires_in`/`id_token`/`refresh_token` to `expiresIn`/`idToken`/`refreshToken`, and `_format_auth_error` to render safe error messages; enforced safe integer parsing of expiry and preserved existing `refreshToken` when refresh responses omit it; removed raw-token messages from exceptions/logging and improved debug messages.
- `custom_components/aquarite/config_flow.py`: Extended the auth form schema with optional `referer` and `origin` fields and passed configured values into `IdentityToolkitAuth` during config flow and pool lookup.
- `custom_components/aquarite/__init__.py`: Read `referer`/`origin` from `entry.options` or `entry.data` and pass them to `IdentityToolkitAuth`, and translate authentication/setup errors to `ConfigEntryAuthFailed` or `ConfigEntryNotReady` respectively.
- `custom_components/aquarite/const.py`: Added `CONF_REFERER` and `CONF_ORIGIN` constants for consistent config keys.

### Testing
- No automated tests were executed for this change.
- Validation was performed via static code inspection of the updated modules to ensure the `signInWithPassword` URL and `securetoken` `/v1/token` URL are used with `?key=` appended, token normalization is applied after JSON parse, and refresh logic preserves `refreshToken` when absent. 
- Ensure to add unit tests for `_normalize_tokens`, `_format_auth_error`, and refresh-edge cases and/or run integration tests in a HA environment before production rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a01510c4832c8de179804abc92c8)