### PR TITLE
Improve integration towards HA platinum quality scale

### DIFF
--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 
 from aioaquarite import AquariteAuth, AquariteClient, AuthenticationError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -28,10 +29,19 @@ PLATFORMS: list[Platform] = [
 ]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Aquarite from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
+@dataclass
+class AquariteRuntimeData:
+    """Runtime data for the Aquarite integration."""
 
+    coordinator: AquariteDataUpdateCoordinator
+    auth: AquariteAuth
+
+
+AquariteConfigEntry = ConfigEntry[AquariteRuntimeData]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> bool:
+    """Set up Aquarite from a config entry."""
     try:
         user_config = entry.data
         session = async_get_clientsession(hass)
@@ -53,14 +63,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Start background tasks (token refresh and health check)
         await coordinator.setup_tasks()
 
-        hass.data[DOMAIN][entry.entry_id] = {
-            "coordinator": coordinator,
-            "auth": auth,
-        }
+        entry.runtime_data = AquariteRuntimeData(
+            coordinator=coordinator,
+            auth=auth,
+        )
 
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-        async def handle_sync_time(call):
+        async def handle_sync_time(call: ServiceCall) -> None:
             """Service call to sync pool time."""
             await coordinator.set_pool_time_to_now()
 
@@ -76,18 +86,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from exc
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: AquariteConfigEntry
+) -> bool:
     """Unload Aquarite config entry."""
-    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if not entry_data:
-        return False
-
-    coordinator = entry_data.get("coordinator")
-
     unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unloaded:
-        await coordinator.async_shutdown()
-        hass.data[DOMAIN].pop(entry.entry_id)
+        await entry.runtime_data.coordinator.async_shutdown()
 
     return unloaded

--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -1,85 +1,223 @@
+"""Aquarite Binary Sensor entities."""
+from __future__ import annotations
+
 from dataclasses import dataclass
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from .entity import AquariteEntity
-from .const import DOMAIN, PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-PROBLEM_VALUE_PATHS = {"hidro.fl1", "hidro.low", "modules.cl.pump_status", "modules.ph.al3", "modules.rx.pump_status"}
-CONNECTIVITY_VALUE_PATHS = {"main.hasCD", "main.hasCL", "main.hasHidro", "main.hasIO", "main.hasPH", "main.hasRX", "present"}
-TANK_MODULE_PATHS = ("modules.ph.tank", "modules.rx.tank", "modules.cl.tank", "modules.cd.tank")
+from . import AquariteConfigEntry
+from .const import PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX
+from .coordinator import AquariteDataUpdateCoordinator
+from .entity import AquariteEntity
+
+TANK_MODULE_PATHS = (
+    "modules.ph.tank",
+    "modules.rx.tank",
+    "modules.cl.tank",
+    "modules.cd.tank",
+)
+
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True)
 class AquariteBinarySensorConfig:
-    name: str
+    """Configuration for an Aquarite binary sensor."""
+
+    translation_key: str
     value_path: str
     device_class: BinarySensorDeviceClass | None = None
+    entity_category: EntityCategory | None = None
+    entity_registry_enabled_default: bool = True
+
 
 BASE_SENSORS: tuple[AquariteBinarySensorConfig, ...] = (
-    AquariteBinarySensorConfig("Hidro Flow Status", "hidro.fl1", BinarySensorDeviceClass.PROBLEM),
-    AquariteBinarySensorConfig("Filtration Status", "filtration.status", BinarySensorDeviceClass.RUNNING),
-    AquariteBinarySensorConfig("Backwash Status", "backwash.status", BinarySensorDeviceClass.RUNNING),
-    AquariteBinarySensorConfig("Hidro Cover Reduction", "hidro.cover", BinarySensorDeviceClass.RUNNING),
-    AquariteBinarySensorConfig("pH Pump Alarm", "modules.ph.al3", BinarySensorDeviceClass.PROBLEM),
-    AquariteBinarySensorConfig("CD Module Installed", "main.hasCD", BinarySensorDeviceClass.CONNECTIVITY),
-    AquariteBinarySensorConfig("CL Module Installed", "main.hasCL", BinarySensorDeviceClass.CONNECTIVITY),
-    AquariteBinarySensorConfig("RX Module Installed", "main.hasRX", BinarySensorDeviceClass.CONNECTIVITY),
-    AquariteBinarySensorConfig("pH Module Installed", "main.hasPH", BinarySensorDeviceClass.CONNECTIVITY),
-    AquariteBinarySensorConfig("IO Module Installed", "main.hasIO", BinarySensorDeviceClass.CONNECTIVITY),
-    AquariteBinarySensorConfig("Hidro Module Installed", "main.hasHidro", BinarySensorDeviceClass.CONNECTIVITY),
-    AquariteBinarySensorConfig("pH Acid Pump", "modules.ph.pump_high_on", BinarySensorDeviceClass.RUNNING),
-    AquariteBinarySensorConfig("Heating Status", "relays.filtration.heating.status", BinarySensorDeviceClass.RUNNING),
-    AquariteBinarySensorConfig("Filtration Smart Freeze", "filtration.smart.freeze", BinarySensorDeviceClass.RUNNING),
-    AquariteBinarySensorConfig("Connected", "present", BinarySensorDeviceClass.CONNECTIVITY),
+    AquariteBinarySensorConfig(
+        "hidro_flow_status", "hidro.fl1", BinarySensorDeviceClass.PROBLEM
+    ),
+    AquariteBinarySensorConfig(
+        "filtration_status", "filtration.status", BinarySensorDeviceClass.RUNNING
+    ),
+    AquariteBinarySensorConfig(
+        "backwash_status", "backwash.status", BinarySensorDeviceClass.RUNNING
+    ),
+    AquariteBinarySensorConfig(
+        "hidro_cover_reduction", "hidro.cover", BinarySensorDeviceClass.RUNNING
+    ),
+    AquariteBinarySensorConfig(
+        "ph_pump_alarm", "modules.ph.al3", BinarySensorDeviceClass.PROBLEM
+    ),
+    AquariteBinarySensorConfig(
+        "cd_module_installed",
+        "main.hasCD",
+        BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    AquariteBinarySensorConfig(
+        "cl_module_installed",
+        "main.hasCL",
+        BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    AquariteBinarySensorConfig(
+        "rx_module_installed",
+        "main.hasRX",
+        BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    AquariteBinarySensorConfig(
+        "ph_module_installed",
+        "main.hasPH",
+        BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    AquariteBinarySensorConfig(
+        "io_module_installed",
+        "main.hasIO",
+        BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    AquariteBinarySensorConfig(
+        "hidro_module_installed",
+        "main.hasHidro",
+        BinarySensorDeviceClass.CONNECTIVITY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    AquariteBinarySensorConfig(
+        "ph_acid_pump", "modules.ph.pump_high_on", BinarySensorDeviceClass.RUNNING
+    ),
+    AquariteBinarySensorConfig(
+        "heating_status",
+        "relays.filtration.heating.status",
+        BinarySensorDeviceClass.RUNNING,
+    ),
+    AquariteBinarySensorConfig(
+        "filtration_smart_freeze",
+        "filtration.smart.freeze",
+        BinarySensorDeviceClass.RUNNING,
+    ),
+    AquariteBinarySensorConfig(
+        "connected", "present", BinarySensorDeviceClass.CONNECTIVITY
+    ),
 )
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> bool:
-    entry_data = hass.data[DOMAIN].get(entry.entry_id)
-    if not entry_data: return False
 
-    dataservice = entry_data["coordinator"]
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: AquariteConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Aquarite binary sensors."""
+    dataservice = entry.runtime_data.coordinator
     pool_id = dataservice.pool_id
     pool_name = entry.title
 
-    entities = [AquariteBinarySensorEntity(hass, dataservice, config, pool_id, pool_name) for config in BASE_SENSORS]
+    entities: list[BinarySensorEntity] = [
+        AquariteBinarySensorEntity(dataservice, config, pool_id, pool_name)
+        for config in BASE_SENSORS
+    ]
 
     if dataservice.get_value("main.hasCL"):
-        entities.append(AquariteBinarySensorEntity(hass, dataservice, AquariteBinarySensorConfig("Hidro FL2 Status", "hidro.fl2", BinarySensorDeviceClass.PROBLEM), pool_id, pool_name))
+        entities.append(
+            AquariteBinarySensorEntity(
+                dataservice,
+                AquariteBinarySensorConfig(
+                    "hidro_fl2_status", "hidro.fl2", BinarySensorDeviceClass.PROBLEM
+                ),
+                pool_id,
+                pool_name,
+            )
+        )
 
-    if any(dataservice.get_value(path) for path in (PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX)):
-        entities.append(AquariteBinarySensorTankEntity(hass, dataservice, "Acid Tank", pool_id, pool_name))
+    if any(
+        dataservice.get_value(path)
+        for path in (PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX)
+    ):
+        entities.append(
+            AquariteBinarySensorTankEntity(dataservice, "acid_tank", pool_id, pool_name)
+        )
 
-    low_label = "Electrolysis Low" if dataservice.get_value("hidro.is_electrolysis") else "Hidrolysis Low"
-    entities.append(AquariteBinarySensorEntity(hass, dataservice, AquariteBinarySensorConfig(low_label, "hidro.low", BinarySensorDeviceClass.PROBLEM), pool_id, pool_name))
+    low_key = (
+        "electrolysis_low"
+        if dataservice.get_value("hidro.is_electrolysis")
+        else "hydrolysis_low"
+    )
+    entities.append(
+        AquariteBinarySensorEntity(
+            dataservice,
+            AquariteBinarySensorConfig(
+                low_key, "hidro.low", BinarySensorDeviceClass.PROBLEM
+            ),
+            pool_id,
+            pool_name,
+        )
+    )
 
     async_add_entities(entities)
-    return True
+
 
 class AquariteBinarySensorEntity(AquariteEntity, BinarySensorEntity):
-    def __init__(self, hass, dataservice, config, pool_id, pool_name):
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=config.name)
-        self._value_path, self._device_class = config.value_path, config.device_class
-        self._attr_unique_id = self.build_unique_id(config.name)
+    """Representation of an Aquarite binary sensor."""
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        config: AquariteBinarySensorConfig,
+        pool_id: str,
+        pool_name: str,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
+        self._value_path = config.value_path
+        self._attr_device_class = config.device_class
+        self._attr_translation_key = config.translation_key
+        self._attr_unique_id = self.build_unique_id(config.translation_key)
+        if config.entity_category is not None:
+            self._attr_entity_category = config.entity_category
+        if not config.entity_registry_enabled_default:
+            self._attr_entity_registry_enabled_default = False
 
     @property
-    def device_class(self):
-        if self._device_class: return self._device_class
-        if self._value_path in PROBLEM_VALUE_PATHS: return BinarySensorDeviceClass.PROBLEM
-        if self._value_path in CONNECTIVITY_VALUE_PATHS: return BinarySensorDeviceClass.CONNECTIVITY
-        return BinarySensorDeviceClass.RUNNING
+    def is_on(self) -> bool | None:
+        """Return true if the binary sensor is on."""
+        value = self._dataservice.get_value(self._value_path)
+        if value is None:
+            return None
+        return bool(value)
 
-    @property
-    def is_on(self):
-        return bool(self._dataservice.get_value(self._value_path))
 
 class AquariteBinarySensorTankEntity(AquariteEntity, BinarySensorEntity):
-    def __init__(self, hass, dataservice, name, pool_id, pool_name):
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
-        self._attr_unique_id, self._attr_device_class = self.build_unique_id(name), BinarySensorDeviceClass.PROBLEM
+    """Tank level binary sensor."""
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        translation_key: str,
+        pool_id: str,
+        pool_name: str,
+    ) -> None:
+        """Initialize the tank sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
 
     @property
-    def is_on(self):
-        return any(self._dataservice.get_value(module) for module in TANK_MODULE_PATHS)
+    def is_on(self) -> bool:
+        """Return true if any tank is low."""
+        return any(
+            self._dataservice.get_value(module) for module in TANK_MODULE_PATHS
+        )

--- a/custom_components/aquarite/config_flow.py
+++ b/custom_components/aquarite/config_flow.py
@@ -1,4 +1,5 @@
-"""Config Flow."""
+"""Config Flow for the Aquarite integration."""
+from __future__ import annotations
 
 from typing import Any
 
@@ -26,6 +27,7 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Aquarite config flow."""
 
     def __init__(self) -> None:
+        """Initialize the config flow."""
         self.data: dict[str, Any] = {}
         self._reauth_entry: config_entries.ConfigEntry | None = None
         self._available_pools: dict[str, str] = {}
@@ -120,3 +122,56 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.context.get("entry_id")
         )
         return await self.async_step_user(user_input)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle reconfiguration of credentials."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            session = async_get_clientsession(self.hass)
+            try:
+                auth = AquariteAuth(
+                    session,
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
+                )
+                await auth.authenticate()
+            except AuthenticationError:
+                errors["base"] = "auth_error"
+            else:
+                reconfigure_entry = self.hass.config_entries.async_get_entry(
+                    self.context.get("entry_id")
+                )
+                if reconfigure_entry:
+                    new_data = {
+                        **reconfigure_entry.data,
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    }
+                    self.hass.config_entries.async_update_entry(
+                        reconfigure_entry, data=new_data
+                    )
+                    await self.hass.config_entries.async_reload(
+                        reconfigure_entry.entry_id
+                    )
+                    return self.async_abort(reason="reconfigure_successful")
+
+        reconfigure_entry = self.hass.config_entries.async_get_entry(
+            self.context.get("entry_id")
+        )
+        default_username = ""
+        if reconfigure_entry:
+            default_username = reconfigure_entry.data.get(CONF_USERNAME, "")
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_USERNAME, default=default_username): cv.string,
+                vol.Required(CONF_PASSWORD): cv.string,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="reconfigure", data_schema=schema, errors=errors
+        )

--- a/custom_components/aquarite/coordinator.py
+++ b/custom_components/aquarite/coordinator.py
@@ -1,10 +1,11 @@
 """Data coordinator for the Aquarite integration."""
+from __future__ import annotations
 
 import asyncio
 import contextlib
 import logging
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from aioaquarite import AquariteAuth, AquariteClient
 
@@ -16,17 +17,19 @@ from .const import HEALTH_CHECK_INTERVAL
 _LOGGER = logging.getLogger(__name__)
 
 
-class AquariteDataUpdateCoordinator(DataUpdateCoordinator):
+class AquariteDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Aquarite coordinator using Firestore real-time snapshots."""
 
     def __init__(
         self, hass: HomeAssistant, auth: AquariteAuth, api: AquariteClient
     ) -> None:
+        """Initialize the coordinator."""
         self.auth = auth
         self.api = api
-        self.pool_id: Optional[str] = None
-        self.watch = None
-        self._health_task: Optional[asyncio.Task] = None
+        self.pool_id: str | None = None
+        self.watch: Any | None = None
+        self._health_task: asyncio.Task[None] | None = None
+        self._token_task: asyncio.Task[None] | None = None
 
         super().__init__(hass, logger=_LOGGER, name="Aquarite", update_interval=None)
 
@@ -37,7 +40,7 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator):
     async def subscribe(self) -> None:
         """Subscribe to Firestore real-time updates via the library."""
 
-        def _on_data(data: dict) -> None:
+        def _on_data(data: dict[str, Any]) -> None:
             """Callback from Firestore thread; push data to HA loop."""
             self.hass.loop.call_soon_threadsafe(self.async_set_updated_data, data)
 
@@ -48,7 +51,7 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator):
         self._health_task = self.hass.async_create_background_task(
             self.periodic_health_check(), "Aquarite health check"
         )
-        self.hass.async_create_background_task(
+        self._token_task = self.hass.async_create_background_task(
             self._token_refresh_loop(), "Aquarite token refresh"
         )
 
@@ -65,9 +68,9 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator):
                 retry_delay = 10
                 sleep_time = self.auth.calculate_sleep_duration()
                 await asyncio.sleep(sleep_time)
-            except Exception as e:
+            except Exception as err:
                 _LOGGER.error(
-                    "Error maintaining token: %s. Retrying in %ss", e, retry_delay
+                    "Error maintaining token: %s. Retrying in %ss", err, retry_delay
                 )
                 await asyncio.sleep(retry_delay)
                 retry_delay = min(retry_delay * 2, 600)
@@ -78,8 +81,8 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator):
             await asyncio.sleep(HEALTH_CHECK_INTERVAL)
             try:
                 await self.auth.get_client()
-            except Exception as e:
-                _LOGGER.error("Health check failed, resubscribing: %s", e)
+            except Exception as err:
+                _LOGGER.error("Health check failed, resubscribing: %s", err)
                 await self.subscribe()
 
     async def refresh_subscription(self) -> None:
@@ -93,10 +96,11 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator):
         """Cleanly unsubscribe and cancel tasks."""
         if self.watch:
             await asyncio.to_thread(self.watch.unsubscribe)
-        if self._health_task:
-            self._health_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._health_task
+        for task in (self._health_task, self._token_task):
+            if task:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
         await super().async_shutdown()
 
     def get_value(self, path: str, default: Any = None) -> Any:

--- a/custom_components/aquarite/device_tracker.py
+++ b/custom_components/aquarite/device_tracker.py
@@ -3,22 +3,24 @@ from __future__ import annotations
 
 from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import AquariteConfigEntry
+from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: AquariteConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the pool location tracker."""
-    entry_data = hass.data[DOMAIN].get(entry.entry_id)
-    if not entry_data:
-        return
-
-    coordinator = entry_data["coordinator"]
+    coordinator = entry.runtime_data.coordinator
     pool_id = coordinator.pool_id
     pool_name = entry.title
 
@@ -26,24 +28,28 @@ async def async_setup_entry(
         PoolLocationDeviceTracker(coordinator, pool_id, pool_name)
     ])
 
+
 class PoolLocationDeviceTracker(AquariteEntity, TrackerEntity):
     """Device tracker representing pool location."""
 
     _attr_source_type = SourceType.GPS
-    _attr_icon = "mdi:pool"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "location"
 
-    def __init__(self, coordinator, pool_id, pool_name) -> None:
+    def __init__(
+        self,
+        coordinator: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+    ) -> None:
         """Initialize the tracker."""
-        # Inherits Device Info and Coordinator logic from your base class
-        super().__init__(coordinator, pool_id, pool_name, name_suffix="Location")
-        # Uses a stable unique ID based on the pool_id
+        super().__init__(coordinator, pool_id, pool_name)
         self._attr_unique_id = f"{pool_id}-location-tracker"
 
     @property
     def latitude(self) -> float | None:
         """Return latitude directly from coordinator data."""
         try:
-            # Pulls from 'form.lat' in the Firestore document
             val = self._dataservice.get_value("form.lat")
             return float(val) if val is not None else None
         except (TypeError, ValueError):
@@ -53,7 +59,6 @@ class PoolLocationDeviceTracker(AquariteEntity, TrackerEntity):
     def longitude(self) -> float | None:
         """Return longitude directly from coordinator data."""
         try:
-            # Pulls from 'form.lng' in the Firestore document
             val = self._dataservice.get_value("form.lng")
             return float(val) if val is not None else None
         except (TypeError, ValueError):

--- a/custom_components/aquarite/diagnostics.py
+++ b/custom_components/aquarite/diagnostics.py
@@ -1,0 +1,27 @@
+"""Diagnostics support for Aquarite."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from . import AquariteConfigEntry
+
+TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: AquariteConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data.coordinator
+
+    return {
+        "entry": {
+            "title": entry.title,
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+        },
+        "coordinator_data": coordinator.data,
+    }

--- a/custom_components/aquarite/entity.py
+++ b/custom_components/aquarite/entity.py
@@ -1,7 +1,7 @@
 """Shared base entity helpers for Aquarite."""
-
 from __future__ import annotations
 
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import BRAND, DOMAIN, MODEL
@@ -18,42 +18,29 @@ class AquariteEntity(CoordinatorEntity[AquariteDataUpdateCoordinator]):
         dataservice: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
-        *,
-        name_suffix: str | None = None,
-        full_name: str | None = None,
     ) -> None:
+        """Initialize the base entity."""
         super().__init__(dataservice)
-        self._dataservice: AquariteDataUpdateCoordinator = dataservice
+        self._dataservice = dataservice
         self._pool_id = pool_id
         self._pool_name = pool_name
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, pool_id)},
-            "name": pool_name,
-            "manufacturer": BRAND,
-            "model": MODEL,
-        }
-
-        if full_name:
-            self._attr_name = full_name
-        elif name_suffix:
-            # When ``_attr_has_entity_name`` is True, Home Assistant automatically
-            # prefixes the device name to the entity name. Provide only the suffix
-            # here to avoid duplicating the pool name in the generated entity ID.
-            self._attr_name = name_suffix
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, pool_id)},
+            name=pool_name,
+            manufacturer=BRAND,
+            model=MODEL,
+        )
 
     @property
     def pool_id(self) -> str:
         """Return the pool ID for the entity."""
-
         return self._pool_id
 
     @property
     def pool_name(self) -> str:
         """Return the friendly pool name for the entity."""
-
         return self._pool_name
 
     def build_unique_id(self, suffix: str, *, delimiter: str = "-") -> str:
         """Return a consistent unique ID for the entity."""
-
         return f"{self._pool_id}{delimiter}{suffix}"

--- a/custom_components/aquarite/icons.json
+++ b/custom_components/aquarite/icons.json
@@ -1,0 +1,123 @@
+{
+  "entity": {
+    "sensor": {
+      "temperature": {
+        "default": "mdi:thermometer"
+      },
+      "ph": {
+        "default": "mdi:ph"
+      },
+      "rx": {
+        "default": "mdi:gauge"
+      },
+      "cd": {
+        "default": "mdi:gauge"
+      },
+      "cl": {
+        "default": "mdi:gauge"
+      },
+      "uv": {
+        "default": "mdi:weather-sunny-alert"
+      },
+      "electrolysis": {
+        "default": "mdi:flash"
+      },
+      "hydrolysis": {
+        "default": "mdi:flash"
+      },
+      "filtration_intel_time": {
+        "default": "mdi:timer-outline"
+      },
+      "filtration_interval_from": {
+        "default": "mdi:clock-start"
+      },
+      "filtration_interval_to": {
+        "default": "mdi:clock-end"
+      },
+      "speed": {
+        "default": "mdi:speedometer"
+      },
+      "pool_name": {
+        "default": "mdi:pool"
+      },
+      "city": {
+        "default": "mdi:city"
+      },
+      "street": {
+        "default": "mdi:road"
+      },
+      "zipcode": {
+        "default": "mdi:numeric"
+      },
+      "country": {
+        "default": "mdi:earth"
+      },
+      "latitude": {
+        "default": "mdi:latitude"
+      },
+      "longitude": {
+        "default": "mdi:longitude"
+      }
+    },
+    "binary_sensor": {
+      "hidro_flow_status": {
+        "default": "mdi:water-alert"
+      },
+      "filtration_status": {
+        "default": "mdi:pump"
+      },
+      "connected": {
+        "default": "mdi:cloud-check"
+      },
+      "acid_tank": {
+        "default": "mdi:bottle-tonic"
+      }
+    },
+    "switch": {
+      "electrolysis_cover": {
+        "default": "mdi:shield-sun"
+      },
+      "electrolysis_boost": {
+        "default": "mdi:flash-alert"
+      },
+      "relay": {
+        "default": "mdi:electric-switch"
+      },
+      "filtration": {
+        "default": "mdi:pump"
+      }
+    },
+    "number": {
+      "redox_setpoint": {
+        "default": "mdi:gauge"
+      },
+      "ph_setpoint": {
+        "default": "mdi:ph"
+      },
+      "electrolysis_setpoint": {
+        "default": "mdi:flash"
+      }
+    },
+    "select": {
+      "pump_mode": {
+        "default": "mdi:pump"
+      },
+      "pump_speed": {
+        "default": "mdi:speedometer"
+      }
+    },
+    "light": {
+      "pool_light": {
+        "default": "mdi:pool"
+      }
+    },
+    "device_tracker": {
+      "location": {
+        "default": "mdi:pool"
+      }
+    }
+  },
+  "services": {
+    "sync_pool_time": "mdi:clock-sync"
+  }
+}

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -1,85 +1,103 @@
 """Aquarite Light entity with State Reconciliation and Failure Handling."""
+from __future__ import annotations
+
 import time
+from typing import Any
+
 from homeassistant.components.light import ColorMode, LightEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import AquariteConfigEntry
+from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
-from .const import DOMAIN
 
 # How long to wait for the cloud to confirm before reverting the UI
-RECONCILIATION_TIMEOUT = 20 
+RECONCILIATION_TIMEOUT = 20
+
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: AquariteConfigEntry,
     async_add_entities: AddEntitiesCallback,
-) -> bool:
+) -> None:
     """Set up the Aquarite light platform."""
-    entry_data = hass.data[DOMAIN].get(entry.entry_id)
-    if not entry_data:
-        return False
-
-    dataservice = entry_data["coordinator"]
+    dataservice = entry.runtime_data.coordinator
     pool_id, pool_name = dataservice.pool_id, entry.title
 
-    entities = [
-        AquariteLightEntity(hass, dataservice, pool_id, pool_name, "Light", "light.status")
-    ]
-    async_add_entities(entities)
-    return True
+    async_add_entities([
+        AquariteLightEntity(dataservice, pool_id, pool_name, "pool_light", "light.status")
+    ])
+
 
 class AquariteLightEntity(AquariteEntity, LightEntity):
-    def __init__(self, hass, dataservice, pool_id, pool_name, name, value_path) -> None:
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
+    """Representation of an Aquarite pool light."""
+
+    _attr_supported_color_modes = {ColorMode.ONOFF}
+    _attr_color_mode = ColorMode.ONOFF
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        translation_key: str,
+        value_path: str,
+    ) -> None:
+        """Initialize the light entity."""
+        super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
-        self._attr_unique_id = self.build_unique_id(name, delimiter="")
-        self._attr_supported_color_modes = {ColorMode.ONOFF}
-        self._attr_color_mode = ColorMode.ONOFF
-        
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
+
         # Reconciliation logic
-        self._target_state = None
-        self._target_set_at = 0
+        self._target_state: bool | None = None
+        self._target_set_at: float = 0
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if light is on."""
         actual_state = bool(self._dataservice.get_value(self._value_path))
-        
-        # 1. If we aren't waiting for a change, show actual state
+
+        # If we aren't waiting for a change, show actual state
         if self._target_state is None:
             return actual_state
 
-        # 2. Check if the cloud has finally matched our request
+        # Check if the cloud has finally matched our request
         if actual_state == self._target_state:
             self._target_state = None
             return actual_state
 
-        # 3. Check if we've waited too long (Timeout)
+        # Check if we've waited too long (Timeout)
         if (time.time() - self._target_set_at) > RECONCILIATION_TIMEOUT:
             self._target_state = None
             return actual_state
 
-        # 4. Otherwise, stay optimistic
+        # Otherwise, stay optimistic
         return self._target_state
 
-    async def _send_command(self, state: bool):
+    async def _send_command(self, state: bool) -> None:
         """Set target state and trigger API."""
         self._target_state = state
         self._target_set_at = time.time()
         self.async_write_ha_state()
-        
+
         try:
-            await self._dataservice.api.set_value(self._pool_id, self._value_path, 1 if state else 0)
+            await self._dataservice.api.set_value(
+                self._pool_id, self._value_path, 1 if state else 0
+            )
         except Exception:
             # If the API call fails immediately, reset and revert UI
             self._target_state = None
             self.async_write_ha_state()
             raise
 
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
         await self._send_command(True)
 
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
         await self._send_command(False)

--- a/custom_components/aquarite/manifest.json
+++ b/custom_components/aquarite/manifest.json
@@ -18,5 +18,5 @@
         "sensor",
         "switch"
     ],
-    "version": "1.0.0"
+    "version": "1.1.0"
 }

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -1,81 +1,111 @@
 """Aquarite Number entities."""
-import logging
+from __future__ import annotations
+
 from typing import Final
 
 from homeassistant.components.number import NumberEntity
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import AquariteConfigEntry
+from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
-_LOGGER = logging.getLogger(__name__)
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: AquariteConfigEntry,
     async_add_entities: AddEntitiesCallback,
-) -> bool:
+) -> None:
     """Set up Aquarite number entities."""
-    entry_data = hass.data[DOMAIN].get(entry.entry_id)
-    if not entry_data:
-        return False
-
-    dataservice = entry_data["coordinator"]
+    dataservice = entry.runtime_data.coordinator
     pool_id, pool_name = dataservice.pool_id, entry.title
-    
+
     # Safely determine max electrolysis
     raw_max = dataservice.get_value("hidro.maxAllowedValue", 0)
     max_electrolysis = int(raw_max) / 10 if raw_max else 50.0
 
     entities = [
-        AquariteNumberEntity(hass, dataservice, pool_id, pool_name, 500, 800, "Redox Setpoint", "modules.rx.status.value"),
-        AquariteNumberEntity(hass, dataservice, pool_id, pool_name, 6, 8, "pH Low", "modules.ph.status.low_value"),
-        AquariteNumberEntity(hass, dataservice, pool_id, pool_name, 6, 8, "pH Max", "modules.ph.status.high_value"),
-        AquariteNumberEntity(hass, dataservice, pool_id, pool_name, 0, max_electrolysis, "Electrolysis Setpoint", "hidro.level"),
+        AquariteNumberEntity(
+            dataservice, pool_id, pool_name,
+            500, 800, "redox_setpoint", "modules.rx.status.value",
+        ),
+        AquariteNumberEntity(
+            dataservice, pool_id, pool_name,
+            6, 8, "ph_low", "modules.ph.status.low_value",
+        ),
+        AquariteNumberEntity(
+            dataservice, pool_id, pool_name,
+            6, 8, "ph_max", "modules.ph.status.high_value",
+        ),
+        AquariteNumberEntity(
+            dataservice, pool_id, pool_name,
+            0, max_electrolysis, "electrolysis_setpoint", "hidro.level",
+        ),
     ]
 
     async_add_entities(entities)
-    return True
 
 
 class AquariteNumberEntity(AquariteEntity, NumberEntity):
     """Number entity for Aquarite data points."""
-    SCALE_MAP: Final = {
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    SCALE_MAP: Final[dict[str, int]] = {
         "modules.ph.status.low_value": 100,
         "modules.ph.status.high_value": 100,
         "hidro.level": 10,
     }
-    UNIT_MAP: Final = {
+    UNIT_MAP: Final[dict[str, str]] = {
         "modules.rx.status.value": "mV",
         "modules.ph.status.low_value": "pH",
         "modules.ph.status.high_value": "pH",
         "hidro.level": "gr/h",
     }
 
-    def __init__(self, hass, dataservice, pool_id, pool_name, value_min, value_max, name, value_path) -> None:
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        value_min: float,
+        value_max: float,
+        translation_key: str,
+        value_path: str,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(dataservice, pool_id, pool_name)
         self._attr_native_min_value = value_min
         self._attr_native_max_value = value_max
         self._value_path = value_path
-        self._attr_unique_id = self.build_unique_id(name)
-        self._attr_unit_of_measurement = self.UNIT_MAP.get(value_path)
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_native_unit_of_measurement = self.UNIT_MAP.get(value_path)
         self._attr_native_step = self._get_scaled_step()
 
     def _get_scaled_step(self) -> float:
+        """Return step size based on scale factor."""
         scale = self.SCALE_MAP.get(self._value_path)
         return 1 / scale if scale else 1.0
 
     @property
-    def native_value(self):
+    def native_value(self) -> float | None:
+        """Return the current value."""
         raw_value = self._dataservice.get_value(self._value_path)
-        if raw_value is None: return None
+        if raw_value is None:
+            return None
         scale = self.SCALE_MAP.get(self._value_path)
         return int(raw_value) / scale if scale else raw_value
 
     async def async_set_native_value(self, value: float) -> None:
+        """Set the value."""
         scale = self.SCALE_MAP.get(self._value_path)
         raw_value = int(value * scale) if scale else value
-        await self._dataservice.api.set_value(self._pool_id, self._value_path, raw_value)
+        await self._dataservice.api.set_value(
+            self._pool_id, self._value_path, raw_value
+        )
         self.async_write_ha_state()

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -1,46 +1,64 @@
 """Aquarite Select entities."""
 from __future__ import annotations
-from collections.abc import Sequence
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import AquariteConfigEntry
+from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
-PUMP_MODE_OPTIONS: tuple[str, ...] = ("Manual", "Auto", "Heat", "Smart", "Intel")
-PUMP_SPEED_OPTIONS: tuple[str, ...] = ("Slow", "Medium", "High")
+PUMP_MODE_OPTIONS: tuple[str, ...] = ("manual", "auto", "heat", "smart", "intel")
+PUMP_SPEED_OPTIONS: tuple[str, ...] = ("slow", "medium", "high")
+
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
-) -> bool:
+    hass: HomeAssistant,
+    entry: AquariteConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up select entities."""
-    entry_data = hass.data[DOMAIN].get(entry.entry_id)
-    if not entry_data:
-        return False
-
-    dataservice = entry_data["coordinator"]
+    dataservice = entry.runtime_data.coordinator
     pool_id, pool_name = dataservice.pool_id, entry.title
 
     async_add_entities([
-        AquaritePumpModeEntity(dataservice, pool_id, pool_name, "Pump Mode", "filtration.mode"),
-        AquaritePumpSpeedEntity(dataservice, pool_id, pool_name, "Pump Speed", "filtration.manVel"),
+        AquariteSelectEntity(
+            dataservice, pool_id, pool_name,
+            "pump_mode", "filtration.mode", PUMP_MODE_OPTIONS,
+        ),
+        AquariteSelectEntity(
+            dataservice, pool_id, pool_name,
+            "pump_speed", "filtration.manVel", PUMP_SPEED_OPTIONS,
+        ),
     ])
-    return True
+
 
 class AquariteSelectEntity(AquariteEntity, SelectEntity):
-    """Base for Aquarite select entities."""
+    """Aquarite select entity."""
 
-    def __init__(self, dataservice, pool_id, pool_name, name, value_path, options) -> None:
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
-        self._value_path, self._options_map = value_path, options
-        self._attr_unique_id = self.build_unique_id(name, delimiter="")
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        translation_key: str,
+        value_path: str,
+        options: tuple[str, ...],
+    ) -> None:
+        """Initialize the select entity."""
+        super().__init__(dataservice, pool_id, pool_name)
+        self._value_path = value_path
+        self._options_map = options
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
         self._attr_options = list(options)
 
     @property
     def current_option(self) -> str | None:
+        """Return the current selected option."""
         raw_value = self._dataservice.get_value(self._value_path)
         try:
             return self._options_map[int(raw_value)]
@@ -48,14 +66,7 @@ class AquariteSelectEntity(AquariteEntity, SelectEntity):
             return None
 
     async def async_select_option(self, option: str) -> None:
+        """Select an option."""
         await self._dataservice.api.set_value(
             self._pool_id, self._value_path, self._options_map.index(option)
         )
-
-class AquaritePumpModeEntity(AquariteSelectEntity):
-    def __init__(self, dataservice, pool_id, pool_name, name, value_path):
-        super().__init__(dataservice, pool_id, pool_name, name, value_path, PUMP_MODE_OPTIONS)
-
-class AquaritePumpSpeedEntity(AquariteSelectEntity):
-    def __init__(self, dataservice, pool_id, pool_name, name, value_path):
-        super().__init__(dataservice, pool_id, pool_name, name, value_path, PUMP_SPEED_OPTIONS)

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -1,14 +1,21 @@
 """Aquarite Sensor entities."""
 from __future__ import annotations
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfElectricPotential, UnitOfTemperature
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    EntityCategory,
+    UnitOfElectricPotential,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import AquariteConfigEntry
 from .const import (
-    DOMAIN,
     PATH_HASCD,
     PATH_HASCL,
     PATH_HASHIDRO,
@@ -16,102 +23,172 @@ from .const import (
     PATH_HASRX,
     PATH_HASUV,
 )
+from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
+
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: AquariteConfigEntry,
     async_add_entities: AddEntitiesCallback,
-) -> bool:
+) -> None:
     """Set up Aquarite sensors."""
-    entry_data = hass.data[DOMAIN].get(entry.entry_id)
-    if not entry_data:
-        return False
-
-    dataservice = entry_data["coordinator"]
+    dataservice = entry.runtime_data.coordinator
     pool_id = dataservice.pool_id
     pool_name = entry.title
 
     entities: list[AquariteEntity] = []
 
     # Temperature Sensors
-    for name, path in (
-        ("Temperature", "main.temperature"),
-        ("Filtration Intel Temperature", "filtration.intel.temp"),
-        ("Filtration Smart Min Temp", "filtration.smart.tempMin"),
-        ("Filtration Smart High Temp", "filtration.smart.tempHigh"),
+    for translation_key, path in (
+        ("temperature", "main.temperature"),
+        ("filtration_intel_temperature", "filtration.intel.temp"),
+        ("filtration_smart_min_temp", "filtration.smart.tempMin"),
+        ("filtration_smart_high_temp", "filtration.smart.tempHigh"),
     ):
         entities.append(
             AquariteTemperatureSensorEntity(
-                hass, dataservice, pool_id, pool_name, name, path
+                dataservice, pool_id, pool_name, translation_key, path
             )
         )
 
     # Module Presence Sensors
     if dataservice.get_value(PATH_HASCD):
-        entities.append(AquariteValueSensorEntity(hass, dataservice, pool_id, pool_name, "CD", "modules.cd.current"))
+        entities.append(
+            AquariteValueSensorEntity(
+                dataservice, pool_id, pool_name, "cd", "modules.cd.current"
+            )
+        )
 
     if dataservice.get_value(PATH_HASCL):
-        entities.append(AquariteValueSensorEntity(hass, dataservice, pool_id, pool_name, "Cl", "modules.cl.current", icon="mdi:gauge"))
+        entities.append(
+            AquariteValueSensorEntity(
+                dataservice, pool_id, pool_name, "cl", "modules.cl.current"
+            )
+        )
 
     if dataservice.get_value(PATH_HASPH):
-        entities.append(AquariteValueSensorEntity(hass, dataservice, pool_id, pool_name, "pH", "modules.ph.current", SensorDeviceClass.PH))
+        entities.append(
+            AquariteValueSensorEntity(
+                dataservice,
+                pool_id,
+                pool_name,
+                "ph",
+                "modules.ph.current",
+                device_class=SensorDeviceClass.PH,
+            )
+        )
 
     if dataservice.get_value(PATH_HASRX):
-        entities.append(AquariteRxValueSensorEntity(hass, dataservice, pool_id, pool_name, "Rx", "modules.rx.current"))
+        entities.append(
+            AquariteRxValueSensorEntity(
+                dataservice, pool_id, pool_name, "rx", "modules.rx.current"
+            )
+        )
 
     if dataservice.get_value(PATH_HASUV):
-        entities.append(AquariteValueSensorEntity(hass, dataservice, pool_id, pool_name, "UV", "modules.uv.current"))
+        entities.append(
+            AquariteValueSensorEntity(
+                dataservice, pool_id, pool_name, "uv", "modules.uv.current"
+            )
+        )
 
     if dataservice.get_value(PATH_HASHIDRO):
-        name = "Electrolysis" if dataservice.get_value("hidro.is_electrolysis") else "Hidrolysis"
-        entities.append(AquariteHydrolyserSensorEntity(hass, dataservice, pool_id, pool_name, name, "hidro.current"))
+        key = (
+            "electrolysis"
+            if dataservice.get_value("hidro.is_electrolysis")
+            else "hydrolysis"
+        )
+        entities.append(
+            AquariteHydrolyserSensorEntity(
+                dataservice, pool_id, pool_name, key, "hidro.current"
+            )
+        )
 
     # Time and Interval Sensors
-    entities.append(AquariteTimeSensorEntity(hass, dataservice, pool_id, pool_name, "Filtration Intel Time", "filtration.intel.time", native_unit_of_measurement="h"))
+    entities.append(
+        AquariteTimeSensorEntity(
+            dataservice,
+            pool_id,
+            pool_name,
+            "filtration_intel_time",
+            "filtration.intel.time",
+            native_unit_of_measurement="h",
+        )
+    )
 
-    for name, path, icon in (
-        ("Filtration Interval 1 From", "filtration.interval1.from", "mdi:clock-start"),
-        ("Filtration Interval 1 To", "filtration.interval1.to", "mdi:clock-end"),
-        ("Filtration Interval 2 From", "filtration.interval2.from", "mdi:clock-start"),
-        ("Filtration Interval 2 To", "filtration.interval2.to", "mdi:clock-end"),
-        ("Filtration Interval 3 From", "filtration.interval3.from", "mdi:clock-start"),
-        ("Filtration Interval 3 To", "filtration.interval3.to", "mdi:clock-end"),
+    for translation_key, path in (
+        ("filtration_interval_1_from", "filtration.interval1.from"),
+        ("filtration_interval_1_to", "filtration.interval1.to"),
+        ("filtration_interval_2_from", "filtration.interval2.from"),
+        ("filtration_interval_2_to", "filtration.interval2.to"),
+        ("filtration_interval_3_from", "filtration.interval3.from"),
+        ("filtration_interval_3_to", "filtration.interval3.to"),
     ):
-        entities.append(AquariteIntervalTimeSensorEntity(hass, dataservice, pool_id, pool_name, name, path, icon))
+        entities.append(
+            AquariteIntervalTimeSensorEntity(
+                dataservice, pool_id, pool_name, translation_key, path
+            )
+        )
 
-    # Speed and Location
+    # Speed sensors
     for index in range(1, 4):
-        entities.append(AquariteSpeedLabelSensorEntity(hass, dataservice, pool_id, pool_name, f"Filtration Timer Speed {index}", f"filtration.timerVel{index}"))
+        entities.append(
+            AquariteSpeedLabelSensorEntity(
+                dataservice,
+                pool_id,
+                pool_name,
+                f"filtration_timer_speed_{index}",
+                f"filtration.timerVel{index}",
+            )
+        )
 
-    for name, key, icon in (
-        ("City", "city", "mdi:city"),
-        ("Street", "street", "mdi:road"),
-        ("Zipcode", "zipcode", "mdi:numeric"),
-        ("Country", "country", "mdi:earth"),
-        ("Latitude", "lat", "mdi:latitude"),
-        ("Longitude", "lng", "mdi:longitude"),
+    # Location sensors (diagnostic)
+    for translation_key, key in (
+        ("city", "city"),
+        ("street", "street"),
+        ("zipcode", "zipcode"),
+        ("country", "country"),
+        ("latitude", "lat"),
+        ("longitude", "lng"),
     ):
-        entities.append(AquariteLocationSensorEntity(hass, dataservice, pool_id, pool_name, name, key, icon))
+        entities.append(
+            AquariteLocationSensorEntity(
+                dataservice, pool_id, pool_name, translation_key, key
+            )
+        )
 
-    entities.append(AquaritePoolNameSensorEntity(hass, dataservice, pool_id, pool_name))
+    entities.append(
+        AquaritePoolNameSensorEntity(dataservice, pool_id, pool_name)
+    )
 
     async_add_entities(entities)
-    return True
 
 
 class AquariteSpeedLabelSensorEntity(AquariteEntity, SensorEntity):
-    _attr_icon = "mdi:speedometer"
-    SPEED_LABELS = {0: "Slow", 1: "Medium", 2: "High"}
+    """Speed label sensor entity."""
 
-    def __init__(self, hass, dataservice, pool_id, pool_name, name, value_path) -> None:
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
+    SPEED_LABELS: dict[int, str] = {0: "Slow", 1: "Medium", 2: "High"}
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        translation_key: str,
+        value_path: str,
+    ) -> None:
+        """Initialize the speed label sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
-        self._attr_unique_id = self.build_unique_id(name)
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
 
     @property
     def native_value(self) -> str:
+        """Return the speed label."""
         value = self._dataservice.get_value(self._value_path)
         try:
             return self.SPEED_LABELS.get(int(value), "Unknown")
@@ -120,14 +197,25 @@ class AquariteSpeedLabelSensorEntity(AquariteEntity, SensorEntity):
 
 
 class AquariteIntervalTimeSensorEntity(AquariteEntity, SensorEntity):
-    def __init__(self, hass, dataservice, pool_id, pool_name, name, value_path, icon=None) -> None:
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
+    """Interval time sensor entity."""
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        translation_key: str,
+        value_path: str,
+    ) -> None:
+        """Initialize the interval time sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
-        self._attr_icon = icon
-        self._attr_unique_id = self.build_unique_id(name)
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
 
     @property
     def native_value(self) -> str | None:
+        """Return the time interval as HH:MM."""
         raw_value = self._dataservice.get_value(self._value_path)
         try:
             seconds = int(raw_value)
@@ -140,16 +228,29 @@ class AquariteIntervalTimeSensorEntity(AquariteEntity, SensorEntity):
 
 
 class AquariteTemperatureSensorEntity(AquariteEntity, SensorEntity):
+    """Temperature sensor entity."""
+
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(self, hass, dataservice, pool_id, pool_name, name, value_path) -> None:
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        translation_key: str,
+        value_path: str,
+    ) -> None:
+        """Initialize the temperature sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
-        self._attr_unique_id = self.build_unique_id(name)
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
 
     @property
     def native_value(self) -> float | None:
+        """Return the temperature value."""
         value = self._dataservice.get_value(self._value_path)
         try:
             return float(value)
@@ -158,14 +259,31 @@ class AquariteTemperatureSensorEntity(AquariteEntity, SensorEntity):
 
 
 class AquariteValueSensorEntity(AquariteEntity, SensorEntity):
-    def __init__(self, hass, dataservice, pool_id, pool_name, name, value_path, device_class=None, native_unit_of_measurement=None, icon=None) -> None:
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
-        self._value_path, self._attr_device_class = value_path, device_class
+    """Generic value sensor entity."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        translation_key: str,
+        value_path: str,
+        device_class: SensorDeviceClass | None = None,
+        native_unit_of_measurement: str | None = None,
+    ) -> None:
+        """Initialize the value sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
+        self._value_path = value_path
+        self._attr_device_class = device_class
         self._attr_native_unit_of_measurement = native_unit_of_measurement
-        self._attr_icon, self._attr_unique_id = icon, self.build_unique_id(name)
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
 
     @property
     def native_value(self) -> float | None:
+        """Return the sensor value."""
         value = self._dataservice.get_value(self._value_path)
         try:
             return float(value) / 100
@@ -174,14 +292,29 @@ class AquariteValueSensorEntity(AquariteEntity, SensorEntity):
 
 
 class AquariteTimeSensorEntity(AquariteEntity, SensorEntity):
-    def __init__(self, hass, dataservice, pool_id, pool_name, name, value_path, device_class=None, native_unit_of_measurement=None, icon=None) -> None:
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
-        self._value_path, self._attr_device_class = value_path, device_class
+    """Time sensor entity."""
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        translation_key: str,
+        value_path: str,
+        device_class: SensorDeviceClass | None = None,
+        native_unit_of_measurement: str | None = None,
+    ) -> None:
+        """Initialize the time sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
+        self._value_path = value_path
+        self._attr_device_class = device_class
         self._attr_native_unit_of_measurement = native_unit_of_measurement
-        self._attr_icon, self._attr_unique_id = icon, self.build_unique_id(name)
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
 
     @property
     def native_value(self) -> float | None:
+        """Return the time value in hours."""
         value = self._dataservice.get_value(self._value_path)
         try:
             return float(value) / 60
@@ -190,16 +323,28 @@ class AquariteTimeSensorEntity(AquariteEntity, SensorEntity):
 
 
 class AquariteHydrolyserSensorEntity(AquariteEntity, SensorEntity):
-    _attr_icon = "mdi:gauge"
-    _attr_native_unit_of_measurement = "gr/h"
+    """Hydrolyser sensor entity."""
 
-    def __init__(self, hass, dataservice, pool_id, pool_name, name, value_path) -> None:
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
+    _attr_native_unit_of_measurement = "gr/h"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        translation_key: str,
+        value_path: str,
+    ) -> None:
+        """Initialize the hydrolyser sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
-        self._attr_unique_id = self.build_unique_id(name)
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
 
     @property
     def native_value(self) -> float | None:
+        """Return the hydrolyser value."""
         value = self._dataservice.get_value(self._value_path)
         try:
             return float(value) / 10
@@ -208,16 +353,28 @@ class AquariteHydrolyserSensorEntity(AquariteEntity, SensorEntity):
 
 
 class AquariteRxValueSensorEntity(AquariteEntity, SensorEntity):
-    _attr_icon = "mdi:gauge"
-    _attr_native_unit_of_measurement = UnitOfElectricPotential.MILLIVOLT
+    """Redox value sensor entity."""
 
-    def __init__(self, hass, dataservice, pool_id, pool_name, name, value_path) -> None:
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
+    _attr_native_unit_of_measurement = UnitOfElectricPotential.MILLIVOLT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        translation_key: str,
+        value_path: str,
+    ) -> None:
+        """Initialize the Rx sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
-        self._attr_unique_id = self.build_unique_id(name)
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
 
     @property
     def native_value(self) -> int | None:
+        """Return the Rx value."""
         value = self._dataservice.get_value(self._value_path)
         try:
             return int(value)
@@ -226,23 +383,48 @@ class AquariteRxValueSensorEntity(AquariteEntity, SensorEntity):
 
 
 class AquariteLocationSensorEntity(AquariteEntity, SensorEntity):
-    def __init__(self, hass, dataservice, pool_id, pool_name, name, form_key, icon=None):
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
-        self._form_key, self._attr_icon = form_key, icon
-        self._attr_unique_id = self.build_unique_id(name)
+    """Location sensor entity."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        translation_key: str,
+        form_key: str,
+    ) -> None:
+        """Initialize the location sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
+        self._form_key = form_key
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
 
     @property
-    def native_value(self):
+    def native_value(self) -> str | None:
+        """Return the location value."""
         form = self._dataservice.get_value("form")
         return form.get(self._form_key) if form else None
 
 
 class AquaritePoolNameSensorEntity(AquariteEntity, SensorEntity):
-    def __init__(self, hass, dataservice, pool_id, pool_name):
-        super().__init__(dataservice, pool_id, pool_name, full_name=f"{pool_name} Name")
+    """Pool name sensor entity."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+    ) -> None:
+        """Initialize the pool name sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
+        self._attr_translation_key = "pool_name"
         self._attr_unique_id = f"{pool_id}-name"
-        self._attr_icon = "mdi:pool"
 
     @property
-    def native_value(self):
+    def native_value(self) -> str:
+        """Return the pool name."""
         return self._pool_name

--- a/custom_components/aquarite/strings.json
+++ b/custom_components/aquarite/strings.json
@@ -15,10 +15,18 @@
       },
       "pool": {
         "data": {
-          "pool_id": "Pools:"
+          "pool_id": "Pool"
         },
         "description": "Please choose the pool for this integration.",
         "title": "Select Pool"
+      },
+      "reconfigure": {
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "description": "Update your Hayward credentials.",
+        "title": "Reconfigure"
       }
     },
     "error": {
@@ -27,7 +35,236 @@
       "unknown_error": "Unexpected error. Please try again."
     },
     "abort": {
-      "reauth_successful": "New login info has been saved"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "temperature": {
+        "name": "Temperature"
+      },
+      "filtration_intel_temperature": {
+        "name": "Filtration intel temperature"
+      },
+      "filtration_smart_min_temp": {
+        "name": "Filtration smart min temperature"
+      },
+      "filtration_smart_high_temp": {
+        "name": "Filtration smart high temperature"
+      },
+      "cd": {
+        "name": "CD"
+      },
+      "cl": {
+        "name": "CL"
+      },
+      "ph": {
+        "name": "pH"
+      },
+      "rx": {
+        "name": "Rx"
+      },
+      "uv": {
+        "name": "UV"
+      },
+      "electrolysis": {
+        "name": "Electrolysis"
+      },
+      "hydrolysis": {
+        "name": "Hydrolysis"
+      },
+      "filtration_intel_time": {
+        "name": "Filtration intel time"
+      },
+      "filtration_interval_1_from": {
+        "name": "Filtration interval 1 from"
+      },
+      "filtration_interval_1_to": {
+        "name": "Filtration interval 1 to"
+      },
+      "filtration_interval_2_from": {
+        "name": "Filtration interval 2 from"
+      },
+      "filtration_interval_2_to": {
+        "name": "Filtration interval 2 to"
+      },
+      "filtration_interval_3_from": {
+        "name": "Filtration interval 3 from"
+      },
+      "filtration_interval_3_to": {
+        "name": "Filtration interval 3 to"
+      },
+      "filtration_timer_speed_1": {
+        "name": "Filtration timer speed 1"
+      },
+      "filtration_timer_speed_2": {
+        "name": "Filtration timer speed 2"
+      },
+      "filtration_timer_speed_3": {
+        "name": "Filtration timer speed 3"
+      },
+      "city": {
+        "name": "City"
+      },
+      "street": {
+        "name": "Street"
+      },
+      "zipcode": {
+        "name": "Zipcode"
+      },
+      "country": {
+        "name": "Country"
+      },
+      "latitude": {
+        "name": "Latitude"
+      },
+      "longitude": {
+        "name": "Longitude"
+      },
+      "pool_name": {
+        "name": "Pool name"
+      }
+    },
+    "binary_sensor": {
+      "hidro_flow_status": {
+        "name": "Hydrolysis flow status"
+      },
+      "filtration_status": {
+        "name": "Filtration status"
+      },
+      "backwash_status": {
+        "name": "Backwash status"
+      },
+      "hidro_cover_reduction": {
+        "name": "Hydrolysis cover reduction"
+      },
+      "ph_pump_alarm": {
+        "name": "pH pump alarm"
+      },
+      "cd_module_installed": {
+        "name": "CD module installed"
+      },
+      "cl_module_installed": {
+        "name": "CL module installed"
+      },
+      "rx_module_installed": {
+        "name": "RX module installed"
+      },
+      "ph_module_installed": {
+        "name": "pH module installed"
+      },
+      "io_module_installed": {
+        "name": "IO module installed"
+      },
+      "hidro_module_installed": {
+        "name": "Hydrolysis module installed"
+      },
+      "ph_acid_pump": {
+        "name": "pH acid pump"
+      },
+      "heating_status": {
+        "name": "Heating status"
+      },
+      "filtration_smart_freeze": {
+        "name": "Filtration smart freeze"
+      },
+      "connected": {
+        "name": "Connected"
+      },
+      "hidro_fl2_status": {
+        "name": "Hydrolysis FL2 status"
+      },
+      "acid_tank": {
+        "name": "Acid tank"
+      },
+      "electrolysis_low": {
+        "name": "Electrolysis low"
+      },
+      "hydrolysis_low": {
+        "name": "Hydrolysis low"
+      }
+    },
+    "switch": {
+      "electrolysis_cover": {
+        "name": "Electrolysis cover"
+      },
+      "electrolysis_boost": {
+        "name": "Electrolysis boost"
+      },
+      "relay_1": {
+        "name": "Relay 1"
+      },
+      "relay_2": {
+        "name": "Relay 2"
+      },
+      "relay_3": {
+        "name": "Relay 3"
+      },
+      "relay_4": {
+        "name": "Relay 4"
+      },
+      "filtration": {
+        "name": "Filtration"
+      }
+    },
+    "number": {
+      "redox_setpoint": {
+        "name": "Redox setpoint"
+      },
+      "ph_low": {
+        "name": "pH low"
+      },
+      "ph_max": {
+        "name": "pH max"
+      },
+      "electrolysis_setpoint": {
+        "name": "Electrolysis setpoint"
+      }
+    },
+    "select": {
+      "pump_mode": {
+        "name": "Pump mode",
+        "state": {
+          "manual": "Manual",
+          "auto": "Auto",
+          "heat": "Heat",
+          "smart": "Smart",
+          "intel": "Intel"
+        }
+      },
+      "pump_speed": {
+        "name": "Pump speed",
+        "state": {
+          "slow": "Slow",
+          "medium": "Medium",
+          "high": "High"
+        }
+      }
+    },
+    "light": {
+      "pool_light": {
+        "name": "Light"
+      }
+    },
+    "device_tracker": {
+      "location": {
+        "name": "Location"
+      }
+    }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the Aquarite device: {error}"
+    },
+    "authentication_error": {
+      "message": "Authentication failed. Please check your credentials."
+    }
+  },
+  "services": {
+    "sync_pool_time": {
+      "name": "Sync pool time",
+      "description": "Sync the Home Assistant date and time to the pool controller."
     }
   }
 }

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -1,59 +1,73 @@
+"""Aquarite Switch entities."""
+from __future__ import annotations
+
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from .const import DOMAIN
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import AquariteConfigEntry
+from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
-# Added Relay 3 and Relay 4 to the definitions
-SWITCH_DEFINITIONS = (
-    ("Electrolysis Cover", "hidro.cover_enabled"),
-    ("Electrolysis Boost", "hidro.cloration_enabled"),
-    ("Relay1", "relays.relay1.info.onoff"),
-    ("Relay2", "relays.relay2.info.onoff"),
-    ("Relay3", "relays.relay3.info.onoff"),
-    ("Relay4", "relays.relay4.info.onoff"),
-    ("Filtration Status", "filtration.status"),
+SWITCH_DEFINITIONS: tuple[tuple[str, str], ...] = (
+    ("electrolysis_cover", "hidro.cover_enabled"),
+    ("electrolysis_boost", "hidro.cloration_enabled"),
+    ("relay_1", "relays.relay1.info.onoff"),
+    ("relay_2", "relays.relay2.info.onoff"),
+    ("relay_3", "relays.relay3.info.onoff"),
+    ("relay_4", "relays.relay4.info.onoff"),
+    ("filtration", "filtration.status"),
 )
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> bool:
-    """Set up the Aquarite switch platform."""
-    entry_data = hass.data[DOMAIN].get(entry.entry_id)
-    if not entry_data:
-        return False
+PARALLEL_UPDATES = 1
 
-    dataservice = entry_data["coordinator"]
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: AquariteConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Aquarite switch platform."""
+    dataservice = entry.runtime_data.coordinator
     pool_id, pool_name = dataservice.pool_id, entry.title
 
     async_add_entities([
-        AquariteSwitchEntity(hass, dataservice, pool_id, pool_name, name, path)
-        for name, path in SWITCH_DEFINITIONS
+        AquariteSwitchEntity(dataservice, pool_id, pool_name, translation_key, path)
+        for translation_key, path in SWITCH_DEFINITIONS
     ])
-    return True
+
 
 class AquariteSwitchEntity(AquariteEntity, SwitchEntity):
     """Representation of an Aquarite switch."""
-    
-    def __init__(self, hass, dataservice, pool_id, pool_name, name, value_path):
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        translation_key: str,
+        value_path: str,
+    ) -> None:
         """Initialize the switch."""
-        super().__init__(dataservice, pool_id, pool_name, name_suffix=name)
+        super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
-        self._attr_unique_id = self.build_unique_id(name, delimiter="")
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(translation_key)
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if switch is on."""
         onoff = bool(self._dataservice.get_value(self._value_path))
-        # Logic to check both the command (onoff) and the feedback status for relays
         if "relay" in self._value_path:
-            status_path = self._value_path.replace('onoff', 'status')
+            status_path = self._value_path.replace("onoff", "status")
             status = bool(self._dataservice.get_value(status_path))
             return onoff or status
         return onoff
 
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs: object) -> None:
         """Turn the switch on."""
         await self._dataservice.api.set_value(self._pool_id, self._value_path, 1)
 
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs: object) -> None:
         """Turn the switch off."""
         await self._dataservice.api.set_value(self._pool_id, self._value_path, 0)

--- a/custom_components/aquarite/translations/en.json
+++ b/custom_components/aquarite/translations/en.json
@@ -10,15 +10,23 @@
         "title": "Authentication"
       },
       "reauth_confirm": {
-        "title": "[%key:common::config_flow::title::reauth%]",
+        "title": "Reauthenticate",
         "description": "Re-authenticate your Hayward account to continue."
       },
       "pool": {
         "data": {
-          "pool_id": "Pools:"
+          "pool_id": "Pool"
         },
         "description": "Please choose the pool for this integration.",
         "title": "Select Pool"
+      },
+      "reconfigure": {
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        },
+        "description": "Update your Hayward credentials.",
+        "title": "Reconfigure"
       }
     },
     "error": {
@@ -27,7 +35,236 @@
       "unknown_error": "Unexpected error. Please try again."
     },
     "abort": {
-      "reauth_successful": "New login info has been saved"
+      "reauth_successful": "Re-authentication was successful.",
+      "reconfigure_successful": "Reconfiguration was successful."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "temperature": {
+        "name": "Temperature"
+      },
+      "filtration_intel_temperature": {
+        "name": "Filtration intel temperature"
+      },
+      "filtration_smart_min_temp": {
+        "name": "Filtration smart min temperature"
+      },
+      "filtration_smart_high_temp": {
+        "name": "Filtration smart high temperature"
+      },
+      "cd": {
+        "name": "CD"
+      },
+      "cl": {
+        "name": "CL"
+      },
+      "ph": {
+        "name": "pH"
+      },
+      "rx": {
+        "name": "Rx"
+      },
+      "uv": {
+        "name": "UV"
+      },
+      "electrolysis": {
+        "name": "Electrolysis"
+      },
+      "hydrolysis": {
+        "name": "Hydrolysis"
+      },
+      "filtration_intel_time": {
+        "name": "Filtration intel time"
+      },
+      "filtration_interval_1_from": {
+        "name": "Filtration interval 1 from"
+      },
+      "filtration_interval_1_to": {
+        "name": "Filtration interval 1 to"
+      },
+      "filtration_interval_2_from": {
+        "name": "Filtration interval 2 from"
+      },
+      "filtration_interval_2_to": {
+        "name": "Filtration interval 2 to"
+      },
+      "filtration_interval_3_from": {
+        "name": "Filtration interval 3 from"
+      },
+      "filtration_interval_3_to": {
+        "name": "Filtration interval 3 to"
+      },
+      "filtration_timer_speed_1": {
+        "name": "Filtration timer speed 1"
+      },
+      "filtration_timer_speed_2": {
+        "name": "Filtration timer speed 2"
+      },
+      "filtration_timer_speed_3": {
+        "name": "Filtration timer speed 3"
+      },
+      "city": {
+        "name": "City"
+      },
+      "street": {
+        "name": "Street"
+      },
+      "zipcode": {
+        "name": "Zipcode"
+      },
+      "country": {
+        "name": "Country"
+      },
+      "latitude": {
+        "name": "Latitude"
+      },
+      "longitude": {
+        "name": "Longitude"
+      },
+      "pool_name": {
+        "name": "Pool name"
+      }
+    },
+    "binary_sensor": {
+      "hidro_flow_status": {
+        "name": "Hydrolysis flow status"
+      },
+      "filtration_status": {
+        "name": "Filtration status"
+      },
+      "backwash_status": {
+        "name": "Backwash status"
+      },
+      "hidro_cover_reduction": {
+        "name": "Hydrolysis cover reduction"
+      },
+      "ph_pump_alarm": {
+        "name": "pH pump alarm"
+      },
+      "cd_module_installed": {
+        "name": "CD module installed"
+      },
+      "cl_module_installed": {
+        "name": "CL module installed"
+      },
+      "rx_module_installed": {
+        "name": "RX module installed"
+      },
+      "ph_module_installed": {
+        "name": "pH module installed"
+      },
+      "io_module_installed": {
+        "name": "IO module installed"
+      },
+      "hidro_module_installed": {
+        "name": "Hydrolysis module installed"
+      },
+      "ph_acid_pump": {
+        "name": "pH acid pump"
+      },
+      "heating_status": {
+        "name": "Heating status"
+      },
+      "filtration_smart_freeze": {
+        "name": "Filtration smart freeze"
+      },
+      "connected": {
+        "name": "Connected"
+      },
+      "hidro_fl2_status": {
+        "name": "Hydrolysis FL2 status"
+      },
+      "acid_tank": {
+        "name": "Acid tank"
+      },
+      "electrolysis_low": {
+        "name": "Electrolysis low"
+      },
+      "hydrolysis_low": {
+        "name": "Hydrolysis low"
+      }
+    },
+    "switch": {
+      "electrolysis_cover": {
+        "name": "Electrolysis cover"
+      },
+      "electrolysis_boost": {
+        "name": "Electrolysis boost"
+      },
+      "relay_1": {
+        "name": "Relay 1"
+      },
+      "relay_2": {
+        "name": "Relay 2"
+      },
+      "relay_3": {
+        "name": "Relay 3"
+      },
+      "relay_4": {
+        "name": "Relay 4"
+      },
+      "filtration": {
+        "name": "Filtration"
+      }
+    },
+    "number": {
+      "redox_setpoint": {
+        "name": "Redox setpoint"
+      },
+      "ph_low": {
+        "name": "pH low"
+      },
+      "ph_max": {
+        "name": "pH max"
+      },
+      "electrolysis_setpoint": {
+        "name": "Electrolysis setpoint"
+      }
+    },
+    "select": {
+      "pump_mode": {
+        "name": "Pump mode",
+        "state": {
+          "manual": "Manual",
+          "auto": "Auto",
+          "heat": "Heat",
+          "smart": "Smart",
+          "intel": "Intel"
+        }
+      },
+      "pump_speed": {
+        "name": "Pump speed",
+        "state": {
+          "slow": "Slow",
+          "medium": "Medium",
+          "high": "High"
+        }
+      }
+    },
+    "light": {
+      "pool_light": {
+        "name": "Light"
+      }
+    },
+    "device_tracker": {
+      "location": {
+        "name": "Location"
+      }
+    }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the Aquarite device: {error}"
+    },
+    "authentication_error": {
+      "message": "Authentication failed. Please check your credentials."
+    }
+  },
+  "services": {
+    "sync_pool_time": {
+      "name": "Sync pool time",
+      "description": "Sync the Home Assistant date and time to the pool controller."
     }
   }
 }


### PR DESCRIPTION
## Summary

- **runtime-data** (Bronze): Replace `hass.data[DOMAIN]` with typed `ConfigEntry.runtime_data` using `AquariteRuntimeData` dataclass
- **parallel-updates** (Silver): Add `PARALLEL_UPDATES` to all 7 platform modules
- **action-exceptions** (Silver): Proper typed service call handler
- **diagnostics** (Gold): New `diagnostics.py` with redacted credential data
- **reconfiguration-flow** (Gold): New `async_step_reconfigure` in config flow
- **entity-category** (Gold): `DIAGNOSTIC` for location/module sensors, `CONFIG` for number setpoints
- **entity-disabled-by-default** (Gold): Module-installed binary sensors disabled by default
- **entity-translations** (Gold): All entities use `translation_key` with full `strings.json` and `translations/en.json` coverage
- **exception-translations** (Gold): Added `exceptions` section to strings.json
- **icon-translations** (Gold): New `icons.json` with icons for all entity types and services
- **entity-device-class** (Gold): Added `SensorStateClass.MEASUREMENT` to measurement sensors
- **strict-typing** (Platinum): Proper type annotations throughout (return types, typed coordinator generic, `DeviceInfo`, typed kwargs)

Also bumps version to 1.1.0.

## Test plan

- [ ] Verify integration loads correctly after update
- [ ] Verify all entities appear with translated names
- [ ] Verify diagnostics download works (Settings > Devices > Aquarite > Download diagnostics)
- [ ] Verify reconfigure flow works (Settings > Integrations > Aquarite > Reconfigure)
- [ ] Verify module-installed binary sensors are disabled by default
- [ ] Verify number entities show under Configuration category
- [ ] Verify location sensors show under Diagnostic category

https://claude.ai/code/session_01LUZiYGpryg1BDvtjmoaC99