### PR TITLE
Improve integration towards HA platinum quality scale

### DIFF
--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -45,6 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> 
     try:
         user_config = entry.data
         session = async_get_clientsession(hass)
+        pool_id: str = user_config["pool_id"]
 
         auth = AquariteAuth(
             session, user_config[CONF_USERNAME], user_config[CONF_PASSWORD]
@@ -53,11 +54,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> 
 
         api = AquariteClient(auth)
 
-        coordinator = AquariteDataUpdateCoordinator(hass, auth, api)
-        coordinator.set_pool_id(user_config["pool_id"])
+        coordinator = AquariteDataUpdateCoordinator(hass, entry, auth, api, pool_id)
 
         # Initial data fetch and subscription
-        coordinator.data = await api.fetch_pool_data(user_config["pool_id"])
+        coordinator.data = await api.fetch_pool_data(pool_id)
         await coordinator.subscribe()
 
         # Start background tasks (token refresh and health check)
@@ -74,8 +74,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> 
             """Service call to sync pool time."""
             await coordinator.set_pool_time_to_now()
 
-        if not hass.services.has_service(DOMAIN, "sync_pool_time"):
+        entry.async_on_unload(
             hass.services.async_register(DOMAIN, "sync_pool_time", handle_sync_time)
+        )
 
         return True
 

--- a/custom_components/aquarite/application_credentials.py
+++ b/custom_components/aquarite/application_credentials.py
@@ -1,6 +1,0 @@
-"""Authentication bridge between Home Assistant and the aioaquarite library."""
-
-from aioaquarite import AuthenticationError
-
-# Re-export for backward compatibility with existing HA integration code
-UnauthorizedException = AuthenticationError

--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -192,7 +192,7 @@ class AquariteBinarySensorEntity(AquariteEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        value = self._dataservice.get_value(self._value_path)
+        value = self.coordinator.get_value(self._value_path)
         if value is None:
             return None
         return bool(value)
@@ -219,5 +219,5 @@ class AquariteBinarySensorTankEntity(AquariteEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return true if any tank is low."""
         return any(
-            self._dataservice.get_value(module) for module in TANK_MODULE_PATHS
+            self.coordinator.get_value(module) for module in TANK_MODULE_PATHS
         )

--- a/custom_components/aquarite/config_flow.py
+++ b/custom_components/aquarite/config_flow.py
@@ -28,7 +28,7 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize the config flow."""
-        self.data: dict[str, Any] = {}
+        self._user_data: dict[str, Any] = {}
         self._reauth_entry: config_entries.ConfigEntry | None = None
         self._available_pools: dict[str, str] = {}
 
@@ -38,7 +38,7 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the user."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            self.data = {
+            self._user_data = {
                 CONF_USERNAME: user_input[CONF_USERNAME],
                 CONF_PASSWORD: user_input[CONF_PASSWORD],
             }
@@ -70,8 +70,8 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
 
             entry_data = {
-                CONF_USERNAME: self.data[CONF_USERNAME],
-                CONF_PASSWORD: self.data[CONF_PASSWORD],
+                CONF_USERNAME: self._user_data[CONF_USERNAME],
+                CONF_PASSWORD: self._user_data[CONF_PASSWORD],
                 "pool_id": pool_id,
             }
             if self._reauth_entry:
@@ -92,8 +92,8 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             session = async_get_clientsession(self.hass)
             auth = AquariteAuth(
                 session,
-                self.data[CONF_USERNAME],
-                self.data[CONF_PASSWORD],
+                self._user_data[CONF_USERNAME],
+                self._user_data[CONF_PASSWORD],
             )
             await auth.authenticate()
 
@@ -115,19 +115,18 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_reauth(
-        self, user_input: dict[str, Any] | None = None
+        self, entry_data: dict[str, Any]
     ) -> FlowResult:
         """Reauthenticate the user."""
-        self._reauth_entry = self.hass.config_entries.async_get_entry(
-            self.context.get("entry_id")
-        )
-        return await self.async_step_user(user_input)
+        self._reauth_entry = self._get_reauth_entry()
+        return await self.async_step_user()
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle reconfiguration of credentials."""
         errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
 
         if user_input is not None:
             session = async_get_clientsession(self.hass)
@@ -141,33 +140,25 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except AuthenticationError:
                 errors["base"] = "auth_error"
             else:
-                reconfigure_entry = self.hass.config_entries.async_get_entry(
-                    self.context.get("entry_id")
+                new_data = {
+                    **reconfigure_entry.data,
+                    CONF_USERNAME: user_input[CONF_USERNAME],
+                    CONF_PASSWORD: user_input[CONF_PASSWORD],
+                }
+                self.hass.config_entries.async_update_entry(
+                    reconfigure_entry, data=new_data
                 )
-                if reconfigure_entry:
-                    new_data = {
-                        **reconfigure_entry.data,
-                        CONF_USERNAME: user_input[CONF_USERNAME],
-                        CONF_PASSWORD: user_input[CONF_PASSWORD],
-                    }
-                    self.hass.config_entries.async_update_entry(
-                        reconfigure_entry, data=new_data
-                    )
-                    await self.hass.config_entries.async_reload(
-                        reconfigure_entry.entry_id
-                    )
-                    return self.async_abort(reason="reconfigure_successful")
-
-        reconfigure_entry = self.hass.config_entries.async_get_entry(
-            self.context.get("entry_id")
-        )
-        default_username = ""
-        if reconfigure_entry:
-            default_username = reconfigure_entry.data.get(CONF_USERNAME, "")
+                await self.hass.config_entries.async_reload(
+                    reconfigure_entry.entry_id
+                )
+                return self.async_abort(reason="reconfigure_successful")
 
         schema = vol.Schema(
             {
-                vol.Required(CONF_USERNAME, default=default_username): cv.string,
+                vol.Required(
+                    CONF_USERNAME,
+                    default=reconfigure_entry.data.get(CONF_USERNAME, ""),
+                ): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
             }
         )

--- a/custom_components/aquarite/coordinator.py
+++ b/custom_components/aquarite/coordinator.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from datetime import datetime
 from typing import Any
 
 from aioaquarite import AquariteAuth, AquariteClient
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from .const import HEALTH_CHECK_INTERVAL
 
@@ -21,21 +22,28 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Aquarite coordinator using Firestore real-time snapshots."""
 
     def __init__(
-        self, hass: HomeAssistant, auth: AquariteAuth, api: AquariteClient
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        auth: AquariteAuth,
+        api: AquariteClient,
+        pool_id: str,
     ) -> None:
         """Initialize the coordinator."""
         self.auth = auth
         self.api = api
-        self.pool_id: str | None = None
+        self.pool_id: str = pool_id
         self.watch: Any | None = None
         self._health_task: asyncio.Task[None] | None = None
         self._token_task: asyncio.Task[None] | None = None
 
-        super().__init__(hass, logger=_LOGGER, name="Aquarite", update_interval=None)
-
-    def set_pool_id(self, pool_id: str) -> None:
-        """Set the pool ID for queries."""
-        self.pool_id = pool_id
+        super().__init__(
+            hass,
+            logger=_LOGGER,
+            name="Aquarite",
+            update_interval=None,
+            config_entry=entry,
+        )
 
     async def subscribe(self) -> None:
         """Subscribe to Firestore real-time updates via the library."""
@@ -109,7 +117,7 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def set_pool_time_to_now(self) -> None:
         """Sync the pool controller clock with the current time."""
-        now = datetime.now()
+        now = dt_util.now()
         payload = {
             "day": now.isoweekday(),
             "hour": now.hour,

--- a/custom_components/aquarite/device_tracker.py
+++ b/custom_components/aquarite/device_tracker.py
@@ -50,7 +50,7 @@ class PoolLocationDeviceTracker(AquariteEntity, TrackerEntity):
     def latitude(self) -> float | None:
         """Return latitude directly from coordinator data."""
         try:
-            val = self._dataservice.get_value("form.lat")
+            val = self.coordinator.get_value("form.lat")
             return float(val) if val is not None else None
         except (TypeError, ValueError):
             return None
@@ -59,7 +59,7 @@ class PoolLocationDeviceTracker(AquariteEntity, TrackerEntity):
     def longitude(self) -> float | None:
         """Return longitude directly from coordinator data."""
         try:
-            val = self._dataservice.get_value("form.lng")
+            val = self.coordinator.get_value("form.lng")
             return float(val) if val is not None else None
         except (TypeError, ValueError):
             return None

--- a/custom_components/aquarite/diagnostics.py
+++ b/custom_components/aquarite/diagnostics.py
@@ -9,7 +9,8 @@ from homeassistant.core import HomeAssistant
 
 from . import AquariteConfigEntry
 
-TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
+TO_REDACT_CONFIG = {CONF_USERNAME, CONF_PASSWORD}
+TO_REDACT_COORDINATOR = {"city", "street", "zipcode", "lat", "lng", "email"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -21,7 +22,9 @@ async def async_get_config_entry_diagnostics(
     return {
         "entry": {
             "title": entry.title,
-            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "data": async_redact_data(dict(entry.data), TO_REDACT_CONFIG),
         },
-        "coordinator_data": coordinator.data,
+        "coordinator_data": async_redact_data(
+            coordinator.data or {}, TO_REDACT_COORDINATOR
+        ),
     }

--- a/custom_components/aquarite/entity.py
+++ b/custom_components/aquarite/entity.py
@@ -15,13 +15,12 @@ class AquariteEntity(CoordinatorEntity[AquariteDataUpdateCoordinator]):
 
     def __init__(
         self,
-        dataservice: AquariteDataUpdateCoordinator,
+        coordinator: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
     ) -> None:
         """Initialize the base entity."""
-        super().__init__(dataservice)
-        self._dataservice = dataservice
+        super().__init__(coordinator)
         self._pool_id = pool_id
         self._pool_name = pool_name
         self._attr_device_info = DeviceInfo(

--- a/custom_components/aquarite/icons.json
+++ b/custom_components/aquarite/icons.json
@@ -4,6 +4,15 @@
       "temperature": {
         "default": "mdi:thermometer"
       },
+      "filtration_intel_temperature": {
+        "default": "mdi:thermometer"
+      },
+      "filtration_smart_min_temp": {
+        "default": "mdi:thermometer"
+      },
+      "filtration_smart_high_temp": {
+        "default": "mdi:thermometer"
+      },
       "ph": {
         "default": "mdi:ph"
       },
@@ -28,13 +37,31 @@
       "filtration_intel_time": {
         "default": "mdi:timer-outline"
       },
-      "filtration_interval_from": {
+      "filtration_interval_1_from": {
         "default": "mdi:clock-start"
       },
-      "filtration_interval_to": {
+      "filtration_interval_1_to": {
         "default": "mdi:clock-end"
       },
-      "speed": {
+      "filtration_interval_2_from": {
+        "default": "mdi:clock-start"
+      },
+      "filtration_interval_2_to": {
+        "default": "mdi:clock-end"
+      },
+      "filtration_interval_3_from": {
+        "default": "mdi:clock-start"
+      },
+      "filtration_interval_3_to": {
+        "default": "mdi:clock-end"
+      },
+      "filtration_timer_speed_1": {
+        "default": "mdi:speedometer"
+      },
+      "filtration_timer_speed_2": {
+        "default": "mdi:speedometer"
+      },
+      "filtration_timer_speed_3": {
         "default": "mdi:speedometer"
       },
       "pool_name": {
@@ -66,11 +93,56 @@
       "filtration_status": {
         "default": "mdi:pump"
       },
+      "backwash_status": {
+        "default": "mdi:pump"
+      },
+      "hidro_cover_reduction": {
+        "default": "mdi:shield-sun"
+      },
+      "ph_pump_alarm": {
+        "default": "mdi:alert"
+      },
+      "cd_module_installed": {
+        "default": "mdi:chip"
+      },
+      "cl_module_installed": {
+        "default": "mdi:chip"
+      },
+      "rx_module_installed": {
+        "default": "mdi:chip"
+      },
+      "ph_module_installed": {
+        "default": "mdi:chip"
+      },
+      "io_module_installed": {
+        "default": "mdi:chip"
+      },
+      "hidro_module_installed": {
+        "default": "mdi:chip"
+      },
+      "ph_acid_pump": {
+        "default": "mdi:pump"
+      },
+      "heating_status": {
+        "default": "mdi:radiator"
+      },
+      "filtration_smart_freeze": {
+        "default": "mdi:snowflake-alert"
+      },
       "connected": {
         "default": "mdi:cloud-check"
       },
+      "hidro_fl2_status": {
+        "default": "mdi:water-alert"
+      },
       "acid_tank": {
         "default": "mdi:bottle-tonic"
+      },
+      "electrolysis_low": {
+        "default": "mdi:flash-alert"
+      },
+      "hydrolysis_low": {
+        "default": "mdi:flash-alert"
       }
     },
     "switch": {
@@ -80,7 +152,16 @@
       "electrolysis_boost": {
         "default": "mdi:flash-alert"
       },
-      "relay": {
+      "relay_1": {
+        "default": "mdi:electric-switch"
+      },
+      "relay_2": {
+        "default": "mdi:electric-switch"
+      },
+      "relay_3": {
+        "default": "mdi:electric-switch"
+      },
+      "relay_4": {
         "default": "mdi:electric-switch"
       },
       "filtration": {
@@ -91,7 +172,10 @@
       "redox_setpoint": {
         "default": "mdi:gauge"
       },
-      "ph_setpoint": {
+      "ph_low": {
+        "default": "mdi:ph"
+      },
+      "ph_max": {
         "default": "mdi:ph"
       },
       "electrolysis_setpoint": {

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -59,7 +59,7 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
     @property
     def is_on(self) -> bool:
         """Return true if light is on."""
-        actual_state = bool(self._dataservice.get_value(self._value_path))
+        actual_state = bool(self.coordinator.get_value(self._value_path))
 
         # If we aren't waiting for a change, show actual state
         if self._target_state is None:
@@ -85,7 +85,7 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
         self.async_write_ha_state()
 
         try:
-            await self._dataservice.api.set_value(
+            await self.coordinator.api.set_value(
                 self._pool_id, self._value_path, 1 if state else 0
             )
         except Exception:

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -95,17 +95,16 @@ class AquariteNumberEntity(AquariteEntity, NumberEntity):
     @property
     def native_value(self) -> float | None:
         """Return the current value."""
-        raw_value = self._dataservice.get_value(self._value_path)
+        raw_value = self.coordinator.get_value(self._value_path)
         if raw_value is None:
             return None
         scale = self.SCALE_MAP.get(self._value_path)
-        return int(raw_value) / scale if scale else raw_value
+        return int(raw_value) / scale if scale else float(raw_value)
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
         scale = self.SCALE_MAP.get(self._value_path)
         raw_value = int(value * scale) if scale else value
-        await self._dataservice.api.set_value(
+        await self.coordinator.api.set_value(
             self._pool_id, self._value_path, raw_value
         )
-        self.async_write_ha_state()

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -59,7 +59,7 @@ class AquariteSelectEntity(AquariteEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the current selected option."""
-        raw_value = self._dataservice.get_value(self._value_path)
+        raw_value = self.coordinator.get_value(self._value_path)
         try:
             return self._options_map[int(raw_value)]
         except (TypeError, ValueError, IndexError):
@@ -67,6 +67,6 @@ class AquariteSelectEntity(AquariteEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Select an option."""
-        await self._dataservice.api.set_value(
+        await self.coordinator.api.set_value(
             self._pool_id, self._value_path, self._options_map.index(option)
         )

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -189,7 +189,7 @@ class AquariteSpeedLabelSensorEntity(AquariteEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return the speed label."""
-        value = self._dataservice.get_value(self._value_path)
+        value = self.coordinator.get_value(self._value_path)
         try:
             return self.SPEED_LABELS.get(int(value), "Unknown")
         except (ValueError, TypeError):
@@ -216,7 +216,7 @@ class AquariteIntervalTimeSensorEntity(AquariteEntity, SensorEntity):
     @property
     def native_value(self) -> str | None:
         """Return the time interval as HH:MM."""
-        raw_value = self._dataservice.get_value(self._value_path)
+        raw_value = self.coordinator.get_value(self._value_path)
         try:
             seconds = int(raw_value)
             hours, minutes = seconds // 3600, (seconds % 3600) // 60
@@ -251,7 +251,7 @@ class AquariteTemperatureSensorEntity(AquariteEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the temperature value."""
-        value = self._dataservice.get_value(self._value_path)
+        value = self.coordinator.get_value(self._value_path)
         try:
             return float(value)
         except (TypeError, ValueError):
@@ -284,7 +284,7 @@ class AquariteValueSensorEntity(AquariteEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the sensor value."""
-        value = self._dataservice.get_value(self._value_path)
+        value = self.coordinator.get_value(self._value_path)
         try:
             return float(value) / 100
         except (TypeError, ValueError):
@@ -315,7 +315,7 @@ class AquariteTimeSensorEntity(AquariteEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the time value in hours."""
-        value = self._dataservice.get_value(self._value_path)
+        value = self.coordinator.get_value(self._value_path)
         try:
             return float(value) / 60
         except (TypeError, ValueError):
@@ -345,7 +345,7 @@ class AquariteHydrolyserSensorEntity(AquariteEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the hydrolyser value."""
-        value = self._dataservice.get_value(self._value_path)
+        value = self.coordinator.get_value(self._value_path)
         try:
             return float(value) / 10
         except (TypeError, ValueError):
@@ -375,7 +375,7 @@ class AquariteRxValueSensorEntity(AquariteEntity, SensorEntity):
     @property
     def native_value(self) -> int | None:
         """Return the Rx value."""
-        value = self._dataservice.get_value(self._value_path)
+        value = self.coordinator.get_value(self._value_path)
         try:
             return int(value)
         except (TypeError, ValueError):
@@ -404,7 +404,7 @@ class AquariteLocationSensorEntity(AquariteEntity, SensorEntity):
     @property
     def native_value(self) -> str | None:
         """Return the location value."""
-        form = self._dataservice.get_value("form")
+        form = self.coordinator.get_value("form")
         return form.get(self._form_key) if form else None
 
 

--- a/custom_components/aquarite/strings.json
+++ b/custom_components/aquarite/strings.json
@@ -9,10 +9,6 @@
         "description": "Enter your Hayward credentials.",
         "title": "Authentication"
       },
-      "reauth_confirm": {
-        "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "Re-authenticate your Hayward account to continue."
-      },
       "pool": {
         "data": {
           "pool_id": "Pool"

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -1,6 +1,8 @@
 """Aquarite Switch entities."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -9,14 +11,24 @@ from . import AquariteConfigEntry
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
-SWITCH_DEFINITIONS: tuple[tuple[str, str], ...] = (
-    ("electrolysis_cover", "hidro.cover_enabled"),
-    ("electrolysis_boost", "hidro.cloration_enabled"),
-    ("relay_1", "relays.relay1.info.onoff"),
-    ("relay_2", "relays.relay2.info.onoff"),
-    ("relay_3", "relays.relay3.info.onoff"),
-    ("relay_4", "relays.relay4.info.onoff"),
-    ("filtration", "filtration.status"),
+
+@dataclass(frozen=True)
+class AquariteSwitchConfig:
+    """Configuration for an Aquarite switch."""
+
+    translation_key: str
+    value_path: str
+    is_relay: bool = False
+
+
+SWITCH_DEFINITIONS: tuple[AquariteSwitchConfig, ...] = (
+    AquariteSwitchConfig("electrolysis_cover", "hidro.cover_enabled"),
+    AquariteSwitchConfig("electrolysis_boost", "hidro.cloration_enabled"),
+    AquariteSwitchConfig("relay_1", "relays.relay1.info.onoff", is_relay=True),
+    AquariteSwitchConfig("relay_2", "relays.relay2.info.onoff", is_relay=True),
+    AquariteSwitchConfig("relay_3", "relays.relay3.info.onoff", is_relay=True),
+    AquariteSwitchConfig("relay_4", "relays.relay4.info.onoff", is_relay=True),
+    AquariteSwitchConfig("filtration", "filtration.status"),
 )
 
 PARALLEL_UPDATES = 1
@@ -32,8 +44,8 @@ async def async_setup_entry(
     pool_id, pool_name = dataservice.pool_id, entry.title
 
     async_add_entities([
-        AquariteSwitchEntity(dataservice, pool_id, pool_name, translation_key, path)
-        for translation_key, path in SWITCH_DEFINITIONS
+        AquariteSwitchEntity(dataservice, pool_id, pool_name, config)
+        for config in SWITCH_DEFINITIONS
     ])
 
 
@@ -42,32 +54,32 @@ class AquariteSwitchEntity(AquariteEntity, SwitchEntity):
 
     def __init__(
         self,
-        dataservice: AquariteDataUpdateCoordinator,
+        coordinator: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
-        translation_key: str,
-        value_path: str,
+        config: AquariteSwitchConfig,
     ) -> None:
         """Initialize the switch."""
-        super().__init__(dataservice, pool_id, pool_name)
-        self._value_path = value_path
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        super().__init__(coordinator, pool_id, pool_name)
+        self._value_path = config.value_path
+        self._is_relay = config.is_relay
+        self._attr_translation_key = config.translation_key
+        self._attr_unique_id = self.build_unique_id(config.translation_key)
 
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
-        onoff = bool(self._dataservice.get_value(self._value_path))
-        if "relay" in self._value_path:
+        onoff = bool(self.coordinator.get_value(self._value_path))
+        if self._is_relay:
             status_path = self._value_path.replace("onoff", "status")
-            status = bool(self._dataservice.get_value(status_path))
+            status = bool(self.coordinator.get_value(status_path))
             return onoff or status
         return onoff
 
     async def async_turn_on(self, **kwargs: object) -> None:
         """Turn the switch on."""
-        await self._dataservice.api.set_value(self._pool_id, self._value_path, 1)
+        await self.coordinator.api.set_value(self._pool_id, self._value_path, 1)
 
     async def async_turn_off(self, **kwargs: object) -> None:
         """Turn the switch off."""
-        await self._dataservice.api.set_value(self._pool_id, self._value_path, 0)
+        await self.coordinator.api.set_value(self._pool_id, self._value_path, 0)

--- a/custom_components/aquarite/translations/en.json
+++ b/custom_components/aquarite/translations/en.json
@@ -9,10 +9,6 @@
         "description": "Enter your Hayward credentials.",
         "title": "Authentication"
       },
-      "reauth_confirm": {
-        "title": "Reauthenticate",
-        "description": "Re-authenticate your Hayward account to continue."
-      },
       "pool": {
         "data": {
           "pool_id": "Pool"


### PR DESCRIPTION
## Summary

Brings the Aquarite integration up to Gold/Platinum level on the HA Integration Quality Scale.

### Bronze
- **runtime-data**: Replace `hass.data[DOMAIN]` with typed `ConfigEntry.runtime_data` using `AquariteRuntimeData` dataclass

### Silver
- **parallel-updates**: Add `PARALLEL_UPDATES` to all 7 platform modules
- **action-exceptions**: Proper typed service call handler

### Gold
- **diagnostics**: New `diagnostics.py` with redacted config + PII-safe coordinator data
- **reconfiguration-flow**: New `async_step_reconfigure` using modern `_get_reconfigure_entry()`
- **entity-category**: `DIAGNOSTIC` for location/module sensors, `CONFIG` for number setpoints
- **entity-disabled-by-default**: Module-installed binary sensors disabled by default
- **entity-translations**: All entities use `translation_key` with full `strings.json` and `translations/en.json`
- **exception-translations**: Added `exceptions` section to strings.json
- **icon-translations**: New `icons.json` with correct keys for all entity types
- **entity-device-class**: Added `SensorStateClass.MEASUREMENT` to measurement sensors

### Platinum
- **strict-typing**: Proper type annotations throughout (typed coordinator generic, `DeviceInfo`, typed kwargs)
- **inject-websession**: Already used `async_get_clientsession` (no change needed)
- **async-dependency**: Already used `aioaquarite` (no change needed)

### Code review fixes
- Use `dt_util.now()` instead of naive `datetime.now()`
- Pass `config_entry` to `DataUpdateCoordinator`, `pool_id` as required `str`
- Use `entry.async_on_unload` for service registration lifecycle
- Use modern `_get_reauth_entry()` / `_get_reconfigure_entry()` in config flow
- Replace redundant `_dataservice` with standard `self.coordinator` across all entities
- Consistent `float` return type from `number.native_value`
- Remove spurious `async_write_ha_state()` in number entity
- Use `is_relay` flag instead of fragile string matching in switch
- Redact PII (city, street, zipcode, lat, lng, email) in diagnostics
- Remove dead `application_credentials.py` and unused `reauth_confirm` strings

Version bumped to 1.1.0.

## Test plan

- [ ] Verify integration loads correctly after update
- [ ] Verify all entities appear with translated names
- [ ] Verify diagnostics download works and redacts PII
- [ ] Verify reconfigure flow works
- [ ] Verify module-installed binary sensors are disabled by default
- [ ] Verify number entities show under Configuration category
- [ ] Verify location sensors show under Diagnostic category
- [ ] Verify service unregisters cleanly on entry unload

https://claude.ai/code/session_01LUZiYGpryg1BDvtjmoaC99