### PR TITLE
Fix service lifecycle, clock safety, translation gaps, and dead code

### DIFF
--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -74,8 +74,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> 
             """Service call to sync pool time."""
             await coordinator.set_pool_time_to_now()
 
+        hass.services.async_register(DOMAIN, "sync_pool_time", handle_sync_time)
         entry.async_on_unload(
-            hass.services.async_register(DOMAIN, "sync_pool_time", handle_sync_time)
+            lambda: hass.services.async_remove(DOMAIN, "sync_pool_time")
         )
 
         return True

--- a/custom_components/aquarite/aquarite.py
+++ b/custom_components/aquarite/aquarite.py
@@ -1,5 +1,0 @@
-"""API client bridge - re-exports from the aioaquarite library."""
-
-from aioaquarite import AquariteClient as Aquarite
-
-__all__ = ["Aquarite"]

--- a/custom_components/aquarite/config_flow.py
+++ b/custom_components/aquarite/config_flow.py
@@ -106,6 +106,13 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         self._available_pools = await api.get_pools()
+
+        if not self._available_pools:
+            errors["base"] = "no_pools_found"
+            return self.async_show_form(
+                step_id="user", data_schema=AUTH_SCHEMA, errors=errors
+            )
+
         pool_schema = vol.Schema(
             {vol.Required("pool_id"): vol.In(self._available_pools)}
         )

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -71,7 +71,7 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
             return actual_state
 
         # Check if we've waited too long (Timeout)
-        if (time.time() - self._target_set_at) > RECONCILIATION_TIMEOUT:
+        if (time.monotonic() - self._target_set_at) > RECONCILIATION_TIMEOUT:
             self._target_state = None
             return actual_state
 
@@ -81,7 +81,7 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
     async def _send_command(self, state: bool) -> None:
         """Set target state and trigger API."""
         self._target_state = state
-        self._target_set_at = time.time()
+        self._target_set_at = time.monotonic()
         self.async_write_ha_state()
 
         try:

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -26,7 +26,10 @@ async def async_setup_entry(
 
     # Safely determine max electrolysis
     raw_max = dataservice.get_value("hidro.maxAllowedValue", 0)
-    max_electrolysis = int(raw_max) / 10 if raw_max else 50.0
+    try:
+        max_electrolysis = int(raw_max) / 10 if raw_max else 50.0
+    except (ValueError, TypeError):
+        max_electrolysis = 50.0
 
     entities = [
         AquariteNumberEntity(

--- a/custom_components/aquarite/services.yaml
+++ b/custom_components/aquarite/services.yaml
@@ -1,4 +1,2 @@
 sync_pool_time:
-  name: Sync pool time
-  description: "Sync the Home Assistant date and time to the pool controller."
   fields: {}

--- a/custom_components/aquarite/translations/da.json
+++ b/custom_components/aquarite/translations/da.json
@@ -6,26 +6,141 @@
           "username": "Hayward brugernavn",
           "password": "Kodeord"
         },
-        "description": "Udfyld dine Hayward login oplysninger.",
+        "description": "Udfyld dine Hayward loginoplysninger.",
         "title": "Login"
-      },
-      "reauth_confirm": {
-        "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "Hayward integrationen kræver at du logger ind igen"
       },
       "pool": {
         "data": {
-          "CONF_POOL_ID": "Pools:"
+          "pool_id": "Pool"
         },
-        "description": "Vælg pool der skal tilføjes HA",
-        "title": "Setup Pool"
+        "description": "Vælg pool der skal tilføjes HA.",
+        "title": "Vælg Pool"
+      },
+      "reconfigure": {
+        "data": {
+          "username": "Brugernavn",
+          "password": "Kodeord"
+        },
+        "description": "Opdater dine Hayward loginoplysninger.",
+        "title": "Genkonfigurer"
       }
     },
     "error": {
-      "auth_error": "Login fejlede, check brugernavn og password."
+      "auth_error": "Login fejlede, tjek brugernavn og kodeord.",
+      "no_pools_found": "Ingen pools fundet for din konto.",
+      "unknown_error": "Uventet fejl. Prøv igen."
     },
     "abort": {
-      "reauth_successful": "Nye login oplysninger gemt"
+      "reauth_successful": "Genautentificering lykkedes.",
+      "reconfigure_successful": "Genkonfigurering lykkedes."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "temperature": { "name": "Temperatur" },
+      "filtration_intel_temperature": { "name": "Filtrering intel temperatur" },
+      "filtration_smart_min_temp": { "name": "Filtrering smart min temperatur" },
+      "filtration_smart_high_temp": { "name": "Filtrering smart høj temperatur" },
+      "cd": { "name": "CD" },
+      "cl": { "name": "CL" },
+      "ph": { "name": "pH" },
+      "rx": { "name": "Rx" },
+      "uv": { "name": "UV" },
+      "electrolysis": { "name": "Elektrolyse" },
+      "hydrolysis": { "name": "Hydrolyse" },
+      "filtration_intel_time": { "name": "Filtrering intel tid" },
+      "filtration_interval_1_from": { "name": "Filtrering interval 1 fra" },
+      "filtration_interval_1_to": { "name": "Filtrering interval 1 til" },
+      "filtration_interval_2_from": { "name": "Filtrering interval 2 fra" },
+      "filtration_interval_2_to": { "name": "Filtrering interval 2 til" },
+      "filtration_interval_3_from": { "name": "Filtrering interval 3 fra" },
+      "filtration_interval_3_to": { "name": "Filtrering interval 3 til" },
+      "filtration_timer_speed_1": { "name": "Filtrering timer hastighed 1" },
+      "filtration_timer_speed_2": { "name": "Filtrering timer hastighed 2" },
+      "filtration_timer_speed_3": { "name": "Filtrering timer hastighed 3" },
+      "city": { "name": "By" },
+      "street": { "name": "Gade" },
+      "zipcode": { "name": "Postnummer" },
+      "country": { "name": "Land" },
+      "latitude": { "name": "Breddegrad" },
+      "longitude": { "name": "Længdegrad" },
+      "pool_name": { "name": "Poolnavn" }
+    },
+    "binary_sensor": {
+      "hidro_flow_status": { "name": "Hydrolyse flow status" },
+      "filtration_status": { "name": "Filtreringsstatus" },
+      "backwash_status": { "name": "Tilbageskylningsstatus" },
+      "hidro_cover_reduction": { "name": "Hydrolyse overdækning reduktion" },
+      "ph_pump_alarm": { "name": "pH pumpe alarm" },
+      "cd_module_installed": { "name": "CD modul installeret" },
+      "cl_module_installed": { "name": "CL modul installeret" },
+      "rx_module_installed": { "name": "RX modul installeret" },
+      "ph_module_installed": { "name": "pH modul installeret" },
+      "io_module_installed": { "name": "IO modul installeret" },
+      "hidro_module_installed": { "name": "Hydrolyse modul installeret" },
+      "ph_acid_pump": { "name": "pH syrepumpe" },
+      "heating_status": { "name": "Opvarmningsstatus" },
+      "filtration_smart_freeze": { "name": "Filtrering smart frost" },
+      "connected": { "name": "Forbundet" },
+      "hidro_fl2_status": { "name": "Hydrolyse FL2 status" },
+      "acid_tank": { "name": "Syretank" },
+      "electrolysis_low": { "name": "Elektrolyse lav" },
+      "hydrolysis_low": { "name": "Hydrolyse lav" }
+    },
+    "switch": {
+      "electrolysis_cover": { "name": "Elektrolyse overdækning" },
+      "electrolysis_boost": { "name": "Elektrolyse boost" },
+      "relay_1": { "name": "Relæ 1" },
+      "relay_2": { "name": "Relæ 2" },
+      "relay_3": { "name": "Relæ 3" },
+      "relay_4": { "name": "Relæ 4" },
+      "filtration": { "name": "Filtrering" }
+    },
+    "number": {
+      "redox_setpoint": { "name": "Redox sætpunkt" },
+      "ph_low": { "name": "pH lav" },
+      "ph_max": { "name": "pH maks" },
+      "electrolysis_setpoint": { "name": "Elektrolyse sætpunkt" }
+    },
+    "select": {
+      "pump_mode": {
+        "name": "Pumpetilstand",
+        "state": {
+          "manual": "Manuel",
+          "auto": "Automatisk",
+          "heat": "Opvarmning",
+          "smart": "Smart",
+          "intel": "Intel"
+        }
+      },
+      "pump_speed": {
+        "name": "Pumpehastighed",
+        "state": {
+          "slow": "Langsom",
+          "medium": "Middel",
+          "high": "Høj"
+        }
+      }
+    },
+    "light": {
+      "pool_light": { "name": "Lys" }
+    },
+    "device_tracker": {
+      "location": { "name": "Placering" }
+    }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "Der opstod en fejl under kommunikation med Aquarite-enheden: {error}"
+    },
+    "authentication_error": {
+      "message": "Godkendelse mislykkedes. Tjek dine loginoplysninger."
+    }
+  },
+  "services": {
+    "sync_pool_time": {
+      "name": "Synkroniser pooltid",
+      "description": "Synkroniser Home Assistant dato og tid til poolcontrolleren."
     }
   }
 }

--- a/custom_components/aquarite/translations/nl.json
+++ b/custom_components/aquarite/translations/nl.json
@@ -1,34 +1,146 @@
 {
-    "config": {
-      "step": {
-        "user": {
-          "data": {
-            "username": "Hayward-gebruikersnaam",
-            "password": "Wachtwoord"
-          },
-          "description": "Vul je Hayward-inloggegevens in.",
-          "title": "Authenticatie"
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "username": "Hayward-gebruikersnaam",
+          "password": "Wachtwoord"
         },
-        "reauth_confirm": {
-          "title": "[%key:common::config_flow::title::reauth%]",
-          "description": "Authenticeer je Hayward-account opnieuw om verder te gaan."
+        "description": "Vul je Hayward-inloggegevens in.",
+        "title": "Authenticatie"
+      },
+      "pool": {
+        "data": {
+          "pool_id": "Zwembad"
         },
-        "pool": {
-          "data": {
-            "pool_id": "Zwembaden:"
-          },
-          "description": "Selecteer het zwembad voor deze integratie.",
-          "title": "Selecteer Zwembad"
+        "description": "Selecteer het zwembad voor deze integratie.",
+        "title": "Selecteer Zwembad"
+      },
+      "reconfigure": {
+        "data": {
+          "username": "Gebruikersnaam",
+          "password": "Wachtwoord"
+        },
+        "description": "Werk je Hayward-inloggegevens bij.",
+        "title": "Herconfigureren"
+      }
+    },
+    "error": {
+      "auth_error": "Autorisatie mislukt, controleer gebruikersnaam en wachtwoord.",
+      "no_pools_found": "Geen zwembaden gevonden voor je account.",
+      "unknown_error": "Onverwachte fout. Probeer het opnieuw."
+    },
+    "abort": {
+      "reauth_successful": "Herauthenticatie is geslaagd.",
+      "reconfigure_successful": "Herconfiguratie is geslaagd."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "temperature": { "name": "Temperatuur" },
+      "filtration_intel_temperature": { "name": "Filtratie intel temperatuur" },
+      "filtration_smart_min_temp": { "name": "Filtratie smart min temperatuur" },
+      "filtration_smart_high_temp": { "name": "Filtratie smart hoge temperatuur" },
+      "cd": { "name": "CD" },
+      "cl": { "name": "CL" },
+      "ph": { "name": "pH" },
+      "rx": { "name": "Rx" },
+      "uv": { "name": "UV" },
+      "electrolysis": { "name": "Elektrolyse" },
+      "hydrolysis": { "name": "Hydrolyse" },
+      "filtration_intel_time": { "name": "Filtratie intel tijd" },
+      "filtration_interval_1_from": { "name": "Filtratie interval 1 van" },
+      "filtration_interval_1_to": { "name": "Filtratie interval 1 tot" },
+      "filtration_interval_2_from": { "name": "Filtratie interval 2 van" },
+      "filtration_interval_2_to": { "name": "Filtratie interval 2 tot" },
+      "filtration_interval_3_from": { "name": "Filtratie interval 3 van" },
+      "filtration_interval_3_to": { "name": "Filtratie interval 3 tot" },
+      "filtration_timer_speed_1": { "name": "Filtratie timer snelheid 1" },
+      "filtration_timer_speed_2": { "name": "Filtratie timer snelheid 2" },
+      "filtration_timer_speed_3": { "name": "Filtratie timer snelheid 3" },
+      "city": { "name": "Stad" },
+      "street": { "name": "Straat" },
+      "zipcode": { "name": "Postcode" },
+      "country": { "name": "Land" },
+      "latitude": { "name": "Breedtegraad" },
+      "longitude": { "name": "Lengtegraad" },
+      "pool_name": { "name": "Zwembadnaam" }
+    },
+    "binary_sensor": {
+      "hidro_flow_status": { "name": "Hydrolyse stroomstatus" },
+      "filtration_status": { "name": "Filtratiestatus" },
+      "backwash_status": { "name": "Terugspoelstatus" },
+      "hidro_cover_reduction": { "name": "Hydrolyse afdekking reductie" },
+      "ph_pump_alarm": { "name": "pH pomp alarm" },
+      "cd_module_installed": { "name": "CD module geïnstalleerd" },
+      "cl_module_installed": { "name": "CL module geïnstalleerd" },
+      "rx_module_installed": { "name": "RX module geïnstalleerd" },
+      "ph_module_installed": { "name": "pH module geïnstalleerd" },
+      "io_module_installed": { "name": "IO module geïnstalleerd" },
+      "hidro_module_installed": { "name": "Hydrolyse module geïnstalleerd" },
+      "ph_acid_pump": { "name": "pH zuurpomp" },
+      "heating_status": { "name": "Verwarmingsstatus" },
+      "filtration_smart_freeze": { "name": "Filtratie smart bevriezing" },
+      "connected": { "name": "Verbonden" },
+      "hidro_fl2_status": { "name": "Hydrolyse FL2 status" },
+      "acid_tank": { "name": "Zuurtank" },
+      "electrolysis_low": { "name": "Elektrolyse laag" },
+      "hydrolysis_low": { "name": "Hydrolyse laag" }
+    },
+    "switch": {
+      "electrolysis_cover": { "name": "Elektrolyse afdekking" },
+      "electrolysis_boost": { "name": "Elektrolyse boost" },
+      "relay_1": { "name": "Relais 1" },
+      "relay_2": { "name": "Relais 2" },
+      "relay_3": { "name": "Relais 3" },
+      "relay_4": { "name": "Relais 4" },
+      "filtration": { "name": "Filtratie" }
+    },
+    "number": {
+      "redox_setpoint": { "name": "Redox instelpunt" },
+      "ph_low": { "name": "pH laag" },
+      "ph_max": { "name": "pH max" },
+      "electrolysis_setpoint": { "name": "Elektrolyse instelpunt" }
+    },
+    "select": {
+      "pump_mode": {
+        "name": "Pompmodus",
+        "state": {
+          "manual": "Handmatig",
+          "auto": "Automatisch",
+          "heat": "Verwarming",
+          "smart": "Smart",
+          "intel": "Intel"
         }
       },
-      "error": {
-        "auth_error": "Autorisatie mislukt, controleer gebruikersnaam en wachtwoord.",
-        "no_pools_found": "Geen zwembaden gevonden voor je account.",
-        "unknown_error": "Onverwachte fout. Probeer het opnieuw."
-      },
-      "abort": {
-        "reauth_successful": "Nieuwe inloggegevens zijn opgeslagen."
+      "pump_speed": {
+        "name": "Pompsnelheid",
+        "state": {
+          "slow": "Langzaam",
+          "medium": "Gemiddeld",
+          "high": "Hoog"
+        }
       }
+    },
+    "light": {
+      "pool_light": { "name": "Licht" }
+    },
+    "device_tracker": {
+      "location": { "name": "Locatie" }
+    }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "Er is een fout opgetreden bij de communicatie met het Aquarite-apparaat: {error}"
+    },
+    "authentication_error": {
+      "message": "Authenticatie mislukt. Controleer je inloggegevens."
+    }
+  },
+  "services": {
+    "sync_pool_time": {
+      "name": "Zwembadtijd synchroniseren",
+      "description": "Synchroniseer de Home Assistant datum en tijd naar de zwembadcontroller."
     }
   }
-  
+}


### PR DESCRIPTION
## Summary

- **Fix service never unregistered on entry unload**: `async_register` returns `None`, so `async_on_unload(None)` was a no-op. Now uses a lambda calling `async_remove` for proper cleanup.
- **Fix light reconciliation clock safety**: Replace `time.time()` with `time.monotonic()` to avoid timeout breakage on NTP sync or clock adjustment.
- **Fix crash on non-numeric API value**: Guard `int(raw_max)` in number setup with try/except for unexpected hidro.maxAllowedValue data.
- **Fix empty pools showing blank dropdown**: Return `no_pools_found` error instead of rendering an empty selector.
- **Fix stale nl.json and da.json**: Add missing reconfigure step, entity translations, exception translations, service translations. Remove deleted reauth_confirm step. Fix `CONF_POOL_ID` key leak in da.json.
- **Clean services.yaml**: Remove name/description duplicated in strings.json.
- **Remove dead aquarite.py**: Unused re-export of AquariteClient.

## Test plan

- [ ] Unload and reload integration entry — verify no orphaned service
- [ ] Toggle pool light and verify UI reconciliation works correctly
- [ ] Set up integration with account that has no pools — verify error shown
- [ ] Switch HA language to Dutch/Danish — verify all entity names translated
- [ ] Verify diagnostics download still works

https://claude.ai/code/session_01LUZiYGpryg1BDvtjmoaC99