### PR TITLE
Fix subscription leak, multi-entry service conflict, and reauth UX

### DIFF
--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -71,13 +71,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> 
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
         async def handle_sync_time(call: ServiceCall) -> None:
-            """Service call to sync pool time."""
-            await coordinator.set_pool_time_to_now()
+            """Service call to sync pool time for all loaded entries."""
+            for config_entry in hass.config_entries.async_entries(DOMAIN):
+                if hasattr(config_entry, "runtime_data") and config_entry.runtime_data:
+                    await config_entry.runtime_data.coordinator.set_pool_time_to_now()
 
-        hass.services.async_register(DOMAIN, "sync_pool_time", handle_sync_time)
-        entry.async_on_unload(
-            lambda: hass.services.async_remove(DOMAIN, "sync_pool_time")
-        )
+        if not hass.services.has_service(DOMAIN, "sync_pool_time"):
+            hass.services.async_register(DOMAIN, "sync_pool_time", handle_sync_time)
+
+        def _maybe_remove_service() -> None:
+            """Remove service if this is the last loaded entry."""
+            remaining = [
+                e
+                for e in hass.config_entries.async_entries(DOMAIN)
+                if e.entry_id != entry.entry_id
+                and hasattr(e, "runtime_data")
+                and e.runtime_data
+            ]
+            if not remaining:
+                hass.services.async_remove(DOMAIN, "sync_pool_time")
+
+        entry.async_on_unload(_maybe_remove_service)
 
         return True
 

--- a/custom_components/aquarite/config_flow.py
+++ b/custom_components/aquarite/config_flow.py
@@ -29,14 +29,12 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the config flow."""
         self._user_data: dict[str, Any] = {}
-        self._reauth_entry: config_entries.ConfigEntry | None = None
         self._available_pools: dict[str, str] = {}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle a flow initialized by the user."""
-        errors: dict[str, str] = {}
         if user_input is not None:
             self._user_data = {
                 CONF_USERNAME: user_input[CONF_USERNAME],
@@ -44,48 +42,25 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
             return await self.async_step_pool()
 
-        schema = AUTH_SCHEMA
-        if self._reauth_entry:
-            schema = vol.Schema(
-                {
-                    vol.Required(
-                        CONF_USERNAME,
-                        default=self._reauth_entry.data.get(CONF_USERNAME, ""),
-                    ): cv.string,
-                    vol.Required(CONF_PASSWORD): cv.string,
-                }
-            )
-
-        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+        return self.async_show_form(step_id="user", data_schema=AUTH_SCHEMA)
 
     async def async_step_pool(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the pool selection step."""
-        errors: dict[str, str] = {}
         if user_input is not None:
             pool_id: str = user_input["pool_id"]
 
             await self.async_set_unique_id(pool_id)
             self._abort_if_unique_id_configured()
 
-            entry_data = {
-                CONF_USERNAME: self._user_data[CONF_USERNAME],
-                CONF_PASSWORD: self._user_data[CONF_PASSWORD],
-                "pool_id": pool_id,
-            }
-            if self._reauth_entry:
-                self.hass.config_entries.async_update_entry(
-                    self._reauth_entry, data=entry_data
-                )
-                await self.hass.config_entries.async_reload(
-                    self._reauth_entry.entry_id
-                )
-                return self.async_abort(reason="reauth_successful")
-
             return self.async_create_entry(
                 title=self._available_pools.get(pool_id, pool_id),
-                data=entry_data,
+                data={
+                    CONF_USERNAME: self._user_data[CONF_USERNAME],
+                    CONF_PASSWORD: self._user_data[CONF_PASSWORD],
+                    "pool_id": pool_id,
+                },
             )
 
         try:
@@ -96,37 +71,76 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._user_data[CONF_PASSWORD],
             )
             await auth.authenticate()
-
-            api = AquariteClient(auth)
-
+            AquariteClient(auth)
         except AuthenticationError:
-            errors["base"] = "auth_error"
             return self.async_show_form(
-                step_id="user", data_schema=AUTH_SCHEMA, errors=errors
+                step_id="user",
+                data_schema=AUTH_SCHEMA,
+                errors={"base": "auth_error"},
             )
 
-        self._available_pools = await api.get_pools()
+        self._available_pools = await AquariteClient(auth).get_pools()
 
         if not self._available_pools:
-            errors["base"] = "no_pools_found"
             return self.async_show_form(
-                step_id="user", data_schema=AUTH_SCHEMA, errors=errors
+                step_id="user",
+                data_schema=AUTH_SCHEMA,
+                errors={"base": "no_pools_found"},
             )
 
         pool_schema = vol.Schema(
             {vol.Required("pool_id"): vol.In(self._available_pools)}
         )
-
-        return self.async_show_form(
-            step_id="pool", data_schema=pool_schema, errors=errors
-        )
+        return self.async_show_form(step_id="pool", data_schema=pool_schema)
 
     async def async_step_reauth(
         self, entry_data: dict[str, Any]
     ) -> FlowResult:
-        """Reauthenticate the user."""
-        self._reauth_entry = self._get_reauth_entry()
-        return await self.async_step_user()
+        """Start reauth flow."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle reauth credential input."""
+        errors: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            session = async_get_clientsession(self.hass)
+            try:
+                auth = AquariteAuth(
+                    session,
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
+                )
+                await auth.authenticate()
+            except AuthenticationError:
+                errors["base"] = "auth_error"
+            else:
+                self.hass.config_entries.async_update_entry(
+                    reauth_entry,
+                    data={
+                        **reauth_entry.data,
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+                await self.hass.config_entries.async_reload(reauth_entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_USERNAME,
+                    default=reauth_entry.data.get(CONF_USERNAME, ""),
+                ): cv.string,
+                vol.Required(CONF_PASSWORD): cv.string,
+            }
+        )
+        return self.async_show_form(
+            step_id="reauth_confirm", data_schema=schema, errors=errors
+        )
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
@@ -147,13 +161,13 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except AuthenticationError:
                 errors["base"] = "auth_error"
             else:
-                new_data = {
-                    **reconfigure_entry.data,
-                    CONF_USERNAME: user_input[CONF_USERNAME],
-                    CONF_PASSWORD: user_input[CONF_PASSWORD],
-                }
                 self.hass.config_entries.async_update_entry(
-                    reconfigure_entry, data=new_data
+                    reconfigure_entry,
+                    data={
+                        **reconfigure_entry.data,
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
                 )
                 await self.hass.config_entries.async_reload(
                     reconfigure_entry.entry_id
@@ -169,7 +183,6 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_PASSWORD): cv.string,
             }
         )
-
         return self.async_show_form(
             step_id="reconfigure", data_schema=schema, errors=errors
         )

--- a/custom_components/aquarite/coordinator.py
+++ b/custom_components/aquarite/coordinator.py
@@ -91,7 +91,7 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await self.auth.get_client()
             except Exception as err:
                 _LOGGER.error("Health check failed, resubscribing: %s", err)
-                await self.subscribe()
+                await self.refresh_subscription()
 
     async def refresh_subscription(self) -> None:
         """Resubscribe to Firestore after a token refresh."""

--- a/custom_components/aquarite/strings.json
+++ b/custom_components/aquarite/strings.json
@@ -9,6 +9,14 @@
         "description": "Enter your Hayward credentials.",
         "title": "Authentication"
       },
+      "reauth_confirm": {
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "description": "Re-authenticate your Hayward account to continue.",
+        "title": "[%key:common::config_flow::title::reauth%]"
+      },
       "pool": {
         "data": {
           "pool_id": "Pool"

--- a/custom_components/aquarite/translations/da.json
+++ b/custom_components/aquarite/translations/da.json
@@ -9,6 +9,14 @@
         "description": "Udfyld dine Hayward loginoplysninger.",
         "title": "Login"
       },
+      "reauth_confirm": {
+        "data": {
+          "username": "Brugernavn",
+          "password": "Kodeord"
+        },
+        "description": "Genautentificer din Hayward-konto for at fortsætte.",
+        "title": "Genautentificer"
+      },
       "pool": {
         "data": {
           "pool_id": "Pool"

--- a/custom_components/aquarite/translations/en.json
+++ b/custom_components/aquarite/translations/en.json
@@ -9,6 +9,14 @@
         "description": "Enter your Hayward credentials.",
         "title": "Authentication"
       },
+      "reauth_confirm": {
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        },
+        "description": "Re-authenticate your Hayward account to continue.",
+        "title": "Reauthenticate"
+      },
       "pool": {
         "data": {
           "pool_id": "Pool"

--- a/custom_components/aquarite/translations/nl.json
+++ b/custom_components/aquarite/translations/nl.json
@@ -9,6 +9,14 @@
         "description": "Vul je Hayward-inloggegevens in.",
         "title": "Authenticatie"
       },
+      "reauth_confirm": {
+        "data": {
+          "username": "Gebruikersnaam",
+          "password": "Wachtwoord"
+        },
+        "description": "Authenticeer je Hayward-account opnieuw om verder te gaan.",
+        "title": "Herauthenticatie"
+      },
       "pool": {
         "data": {
           "pool_id": "Zwembad"


### PR DESCRIPTION
## Summary

- **Fix Firestore subscription leak**: `periodic_health_check` called `subscribe()` directly on failure, leaking the old watch and creating duplicate data callbacks. Now calls `refresh_subscription()` which unsubscribes the old watch first.
- **Fix multi-entry service conflict**: `sync_pool_time` service is now registered once globally and iterates all loaded entries, so it works with multiple pools. Only removed when the last entry is unloaded.
- **Fix reauth skipping pool re-selection**: Reauth now uses a dedicated `reauth_confirm` step that only asks for credentials, instead of routing through the full user→pool flow. Users no longer need to re-select their pool just to update a password.

## Test plan

- [ ] Trigger a health check failure (e.g. temporary network drop) — verify no duplicate entity updates after reconnection
- [ ] Set up two pool entries — verify sync_pool_time works for both pools
- [ ] Unload one of two entries — verify service still works for the remaining entry
- [ ] Trigger reauth — verify only username/password are requested, not pool selection

https://claude.ai/code/session_01LUZiYGpryg1BDvtjmoaC99