### PR TITLE
Fix config flow error handling and subscription race condition

### DIFF
--- a/custom_components/aquarite/config_flow.py
+++ b/custom_components/aquarite/config_flow.py
@@ -71,15 +71,20 @@ class AquariteConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._user_data[CONF_PASSWORD],
             )
             await auth.authenticate()
-            AquariteClient(auth)
+            api = AquariteClient(auth)
+            self._available_pools = await api.get_pools()
         except AuthenticationError:
             return self.async_show_form(
                 step_id="user",
                 data_schema=AUTH_SCHEMA,
                 errors={"base": "auth_error"},
             )
-
-        self._available_pools = await AquariteClient(auth).get_pools()
+        except Exception:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=AUTH_SCHEMA,
+                errors={"base": "unknown_error"},
+            )
 
         if not self._available_pools:
             return self.async_show_form(

--- a/custom_components/aquarite/coordinator.py
+++ b/custom_components/aquarite/coordinator.py
@@ -36,6 +36,7 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.watch: Any | None = None
         self._health_task: asyncio.Task[None] | None = None
         self._token_task: asyncio.Task[None] | None = None
+        self._subscription_lock = asyncio.Lock()
 
         super().__init__(
             hass,
@@ -95,10 +96,11 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def refresh_subscription(self) -> None:
         """Resubscribe to Firestore after a token refresh."""
-        _LOGGER.debug("Refreshing Firestore subscription for %s", self.pool_id)
-        if self.watch:
-            await asyncio.to_thread(self.watch.unsubscribe)
-        await self.subscribe()
+        async with self._subscription_lock:
+            _LOGGER.debug("Refreshing Firestore subscription for %s", self.pool_id)
+            if self.watch:
+                await asyncio.to_thread(self.watch.unsubscribe)
+            await self.subscribe()
 
     async def async_shutdown(self) -> None:
         """Cleanly unsubscribe and cancel tasks."""


### PR DESCRIPTION
## Summary

- **Fix wasted client + unhandled get_pools() error**: Removed duplicate `AquariteClient` instantiation in pool step. Moved `get_pools()` inside the try block so network or API errors after successful auth show `unknown_error` instead of crashing the config flow.
- **Fix subscription race condition**: Added `asyncio.Lock` around `refresh_subscription()` to prevent concurrent calls from the token refresh loop and health check from racing and leaking a Firestore watch.

## Test plan

- [ ] Set up integration with valid credentials but simulate API failure on pool fetch — verify friendly error shown
- [ ] Verify normal setup flow still works end-to-end
- [ ] Trigger concurrent token refresh + health check failure — verify no duplicate Firestore subscriptions

https://claude.ai/code/session_01LUZiYGpryg1BDvtjmoaC99