### PR TITLE
Preserve original unique_ids to prevent breaking existing entities on upgrade

### DIFF
--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -30,6 +30,7 @@ PARALLEL_UPDATES = 0
 class AquariteBinarySensorConfig:
     """Configuration for an Aquarite binary sensor."""
 
+    name: str
     translation_key: str
     value_path: str
     device_class: BinarySensorDeviceClass | None = None
@@ -39,77 +40,77 @@ class AquariteBinarySensorConfig:
 
 BASE_SENSORS: tuple[AquariteBinarySensorConfig, ...] = (
     AquariteBinarySensorConfig(
-        "hidro_flow_status", "hidro.fl1", BinarySensorDeviceClass.PROBLEM
+        "Hidro Flow Status", "hidro_flow_status", "hidro.fl1", BinarySensorDeviceClass.PROBLEM
     ),
     AquariteBinarySensorConfig(
-        "filtration_status", "filtration.status", BinarySensorDeviceClass.RUNNING
+        "Filtration Status", "filtration_status", "filtration.status", BinarySensorDeviceClass.RUNNING
     ),
     AquariteBinarySensorConfig(
-        "backwash_status", "backwash.status", BinarySensorDeviceClass.RUNNING
+        "Backwash Status", "backwash_status", "backwash.status", BinarySensorDeviceClass.RUNNING
     ),
     AquariteBinarySensorConfig(
-        "hidro_cover_reduction", "hidro.cover", BinarySensorDeviceClass.RUNNING
+        "Hidro Cover Reduction", "hidro_cover_reduction", "hidro.cover", BinarySensorDeviceClass.RUNNING
     ),
     AquariteBinarySensorConfig(
-        "ph_pump_alarm", "modules.ph.al3", BinarySensorDeviceClass.PROBLEM
+        "pH Pump Alarm", "ph_pump_alarm", "modules.ph.al3", BinarySensorDeviceClass.PROBLEM
     ),
     AquariteBinarySensorConfig(
-        "cd_module_installed",
+        "CD Module Installed", "cd_module_installed",
         "main.hasCD",
         BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     AquariteBinarySensorConfig(
-        "cl_module_installed",
+        "CL Module Installed", "cl_module_installed",
         "main.hasCL",
         BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     AquariteBinarySensorConfig(
-        "rx_module_installed",
+        "RX Module Installed", "rx_module_installed",
         "main.hasRX",
         BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     AquariteBinarySensorConfig(
-        "ph_module_installed",
+        "pH Module Installed", "ph_module_installed",
         "main.hasPH",
         BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     AquariteBinarySensorConfig(
-        "io_module_installed",
+        "IO Module Installed", "io_module_installed",
         "main.hasIO",
         BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     AquariteBinarySensorConfig(
-        "hidro_module_installed",
+        "Hidro Module Installed", "hidro_module_installed",
         "main.hasHidro",
         BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     AquariteBinarySensorConfig(
-        "ph_acid_pump", "modules.ph.pump_high_on", BinarySensorDeviceClass.RUNNING
+        "pH Acid Pump", "ph_acid_pump", "modules.ph.pump_high_on", BinarySensorDeviceClass.RUNNING
     ),
     AquariteBinarySensorConfig(
-        "heating_status",
+        "Heating Status", "heating_status",
         "relays.filtration.heating.status",
         BinarySensorDeviceClass.RUNNING,
     ),
     AquariteBinarySensorConfig(
-        "filtration_smart_freeze",
+        "Filtration Smart Freeze", "filtration_smart_freeze",
         "filtration.smart.freeze",
         BinarySensorDeviceClass.RUNNING,
     ),
     AquariteBinarySensorConfig(
-        "connected", "present", BinarySensorDeviceClass.CONNECTIVITY
+        "Connected", "connected", "present", BinarySensorDeviceClass.CONNECTIVITY
     ),
 )
 
@@ -134,7 +135,8 @@ async def async_setup_entry(
             AquariteBinarySensorEntity(
                 dataservice,
                 AquariteBinarySensorConfig(
-                    "hidro_fl2_status", "hidro.fl2", BinarySensorDeviceClass.PROBLEM
+                    "Hidro FL2 Status", "hidro_fl2_status",
+                    "hidro.fl2", BinarySensorDeviceClass.PROBLEM,
                 ),
                 pool_id,
                 pool_name,
@@ -146,19 +148,19 @@ async def async_setup_entry(
         for path in (PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX)
     ):
         entities.append(
-            AquariteBinarySensorTankEntity(dataservice, "acid_tank", pool_id, pool_name)
+            AquariteBinarySensorTankEntity(
+                dataservice, "Acid Tank", "acid_tank", pool_id, pool_name
+            )
         )
 
-    low_key = (
-        "electrolysis_low"
-        if dataservice.get_value("hidro.is_electrolysis")
-        else "hydrolysis_low"
-    )
+    is_electrolysis = dataservice.get_value("hidro.is_electrolysis")
+    low_name = "Electrolysis Low" if is_electrolysis else "Hidrolysis Low"
+    low_key = "electrolysis_low" if is_electrolysis else "hydrolysis_low"
     entities.append(
         AquariteBinarySensorEntity(
             dataservice,
             AquariteBinarySensorConfig(
-                low_key, "hidro.low", BinarySensorDeviceClass.PROBLEM
+                low_name, low_key, "hidro.low", BinarySensorDeviceClass.PROBLEM
             ),
             pool_id,
             pool_name,
@@ -183,7 +185,7 @@ class AquariteBinarySensorEntity(AquariteEntity, BinarySensorEntity):
         self._value_path = config.value_path
         self._attr_device_class = config.device_class
         self._attr_translation_key = config.translation_key
-        self._attr_unique_id = self.build_unique_id(config.translation_key)
+        self._attr_unique_id = self.build_unique_id(config.name)
         if config.entity_category is not None:
             self._attr_entity_category = config.entity_category
         if not config.entity_registry_enabled_default:
@@ -206,6 +208,7 @@ class AquariteBinarySensorTankEntity(AquariteEntity, BinarySensorEntity):
     def __init__(
         self,
         dataservice: AquariteDataUpdateCoordinator,
+        name: str,
         translation_key: str,
         pool_id: str,
         pool_name: str,
@@ -213,7 +216,7 @@ class AquariteBinarySensorTankEntity(AquariteEntity, BinarySensorEntity):
         """Initialize the tank sensor."""
         super().__init__(dataservice, pool_id, pool_name)
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -28,7 +28,7 @@ async def async_setup_entry(
     pool_id, pool_name = dataservice.pool_id, entry.title
 
     async_add_entities([
-        AquariteLightEntity(dataservice, pool_id, pool_name, "pool_light", "light.status")
+        AquariteLightEntity(dataservice, pool_id, pool_name, "Light", "pool_light", "light.status")
     ])
 
 
@@ -43,6 +43,7 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
         dataservice: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
+        name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
@@ -50,7 +51,7 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
         super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name, delimiter="")
 
         # Reconciliation logic
         self._target_state: bool | None = None

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -34,19 +34,19 @@ async def async_setup_entry(
     entities = [
         AquariteNumberEntity(
             dataservice, pool_id, pool_name,
-            500, 800, "redox_setpoint", "modules.rx.status.value",
+            500, 800, "Redox Setpoint", "redox_setpoint", "modules.rx.status.value",
         ),
         AquariteNumberEntity(
             dataservice, pool_id, pool_name,
-            6, 8, "ph_low", "modules.ph.status.low_value",
+            6, 8, "pH Low", "ph_low", "modules.ph.status.low_value",
         ),
         AquariteNumberEntity(
             dataservice, pool_id, pool_name,
-            6, 8, "ph_max", "modules.ph.status.high_value",
+            6, 8, "pH Max", "ph_max", "modules.ph.status.high_value",
         ),
         AquariteNumberEntity(
             dataservice, pool_id, pool_name,
-            0, max_electrolysis, "electrolysis_setpoint", "hidro.level",
+            0, max_electrolysis, "Electrolysis Setpoint", "electrolysis_setpoint", "hidro.level",
         ),
     ]
 
@@ -77,6 +77,7 @@ class AquariteNumberEntity(AquariteEntity, NumberEntity):
         pool_name: str,
         value_min: float,
         value_max: float,
+        name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
@@ -86,7 +87,7 @@ class AquariteNumberEntity(AquariteEntity, NumberEntity):
         self._attr_native_max_value = value_max
         self._value_path = value_path
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name)
         self._attr_native_unit_of_measurement = self.UNIT_MAP.get(value_path)
         self._attr_native_step = self._get_scaled_step()
 

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -27,11 +27,11 @@ async def async_setup_entry(
     async_add_entities([
         AquariteSelectEntity(
             dataservice, pool_id, pool_name,
-            "pump_mode", "filtration.mode", PUMP_MODE_OPTIONS,
+            "Pump Mode", "pump_mode", "filtration.mode", PUMP_MODE_OPTIONS,
         ),
         AquariteSelectEntity(
             dataservice, pool_id, pool_name,
-            "pump_speed", "filtration.manVel", PUMP_SPEED_OPTIONS,
+            "Pump Speed", "pump_speed", "filtration.manVel", PUMP_SPEED_OPTIONS,
         ),
     ])
 
@@ -44,6 +44,7 @@ class AquariteSelectEntity(AquariteEntity, SelectEntity):
         dataservice: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
+        name: str,
         translation_key: str,
         value_path: str,
         options: tuple[str, ...],
@@ -53,7 +54,7 @@ class AquariteSelectEntity(AquariteEntity, SelectEntity):
         self._value_path = value_path
         self._options_map = options
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name, delimiter="")
         self._attr_options = list(options)
 
     @property

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -42,15 +42,15 @@ async def async_setup_entry(
     entities: list[AquariteEntity] = []
 
     # Temperature Sensors
-    for translation_key, path in (
-        ("temperature", "main.temperature"),
-        ("filtration_intel_temperature", "filtration.intel.temp"),
-        ("filtration_smart_min_temp", "filtration.smart.tempMin"),
-        ("filtration_smart_high_temp", "filtration.smart.tempHigh"),
+    for name, translation_key, path in (
+        ("Temperature", "temperature", "main.temperature"),
+        ("Filtration Intel Temperature", "filtration_intel_temperature", "filtration.intel.temp"),
+        ("Filtration Smart Min Temp", "filtration_smart_min_temp", "filtration.smart.tempMin"),
+        ("Filtration Smart High Temp", "filtration_smart_high_temp", "filtration.smart.tempHigh"),
     ):
         entities.append(
             AquariteTemperatureSensorEntity(
-                dataservice, pool_id, pool_name, translation_key, path
+                dataservice, pool_id, pool_name, name, translation_key, path
             )
         )
 
@@ -58,24 +58,21 @@ async def async_setup_entry(
     if dataservice.get_value(PATH_HASCD):
         entities.append(
             AquariteValueSensorEntity(
-                dataservice, pool_id, pool_name, "cd", "modules.cd.current"
+                dataservice, pool_id, pool_name, "CD", "cd", "modules.cd.current"
             )
         )
 
     if dataservice.get_value(PATH_HASCL):
         entities.append(
             AquariteValueSensorEntity(
-                dataservice, pool_id, pool_name, "cl", "modules.cl.current"
+                dataservice, pool_id, pool_name, "Cl", "cl", "modules.cl.current"
             )
         )
 
     if dataservice.get_value(PATH_HASPH):
         entities.append(
             AquariteValueSensorEntity(
-                dataservice,
-                pool_id,
-                pool_name,
-                "ph",
+                dataservice, pool_id, pool_name, "pH", "ph",
                 "modules.ph.current",
                 device_class=SensorDeviceClass.PH,
             )
@@ -84,52 +81,48 @@ async def async_setup_entry(
     if dataservice.get_value(PATH_HASRX):
         entities.append(
             AquariteRxValueSensorEntity(
-                dataservice, pool_id, pool_name, "rx", "modules.rx.current"
+                dataservice, pool_id, pool_name, "Rx", "rx", "modules.rx.current"
             )
         )
 
     if dataservice.get_value(PATH_HASUV):
         entities.append(
             AquariteValueSensorEntity(
-                dataservice, pool_id, pool_name, "uv", "modules.uv.current"
+                dataservice, pool_id, pool_name, "UV", "uv", "modules.uv.current"
             )
         )
 
     if dataservice.get_value(PATH_HASHIDRO):
-        key = (
-            "electrolysis"
-            if dataservice.get_value("hidro.is_electrolysis")
-            else "hydrolysis"
-        )
+        is_electrolysis = dataservice.get_value("hidro.is_electrolysis")
+        name = "Electrolysis" if is_electrolysis else "Hidrolysis"
+        key = "electrolysis" if is_electrolysis else "hydrolysis"
         entities.append(
             AquariteHydrolyserSensorEntity(
-                dataservice, pool_id, pool_name, key, "hidro.current"
+                dataservice, pool_id, pool_name, name, key, "hidro.current"
             )
         )
 
     # Time and Interval Sensors
     entities.append(
         AquariteTimeSensorEntity(
-            dataservice,
-            pool_id,
-            pool_name,
-            "filtration_intel_time",
+            dataservice, pool_id, pool_name,
+            "Filtration Intel Time", "filtration_intel_time",
             "filtration.intel.time",
             native_unit_of_measurement="h",
         )
     )
 
-    for translation_key, path in (
-        ("filtration_interval_1_from", "filtration.interval1.from"),
-        ("filtration_interval_1_to", "filtration.interval1.to"),
-        ("filtration_interval_2_from", "filtration.interval2.from"),
-        ("filtration_interval_2_to", "filtration.interval2.to"),
-        ("filtration_interval_3_from", "filtration.interval3.from"),
-        ("filtration_interval_3_to", "filtration.interval3.to"),
+    for name, translation_key, path in (
+        ("Filtration Interval 1 From", "filtration_interval_1_from", "filtration.interval1.from"),
+        ("Filtration Interval 1 To", "filtration_interval_1_to", "filtration.interval1.to"),
+        ("Filtration Interval 2 From", "filtration_interval_2_from", "filtration.interval2.from"),
+        ("Filtration Interval 2 To", "filtration_interval_2_to", "filtration.interval2.to"),
+        ("Filtration Interval 3 From", "filtration_interval_3_from", "filtration.interval3.from"),
+        ("Filtration Interval 3 To", "filtration_interval_3_to", "filtration.interval3.to"),
     ):
         entities.append(
             AquariteIntervalTimeSensorEntity(
-                dataservice, pool_id, pool_name, translation_key, path
+                dataservice, pool_id, pool_name, name, translation_key, path
             )
         )
 
@@ -137,26 +130,25 @@ async def async_setup_entry(
     for index in range(1, 4):
         entities.append(
             AquariteSpeedLabelSensorEntity(
-                dataservice,
-                pool_id,
-                pool_name,
+                dataservice, pool_id, pool_name,
+                f"Filtration Timer Speed {index}",
                 f"filtration_timer_speed_{index}",
                 f"filtration.timerVel{index}",
             )
         )
 
     # Location sensors (diagnostic)
-    for translation_key, key in (
-        ("city", "city"),
-        ("street", "street"),
-        ("zipcode", "zipcode"),
-        ("country", "country"),
-        ("latitude", "lat"),
-        ("longitude", "lng"),
+    for name, translation_key, key in (
+        ("City", "city", "city"),
+        ("Street", "street", "street"),
+        ("Zipcode", "zipcode", "zipcode"),
+        ("Country", "country", "country"),
+        ("Latitude", "latitude", "lat"),
+        ("Longitude", "longitude", "lng"),
     ):
         entities.append(
             AquariteLocationSensorEntity(
-                dataservice, pool_id, pool_name, translation_key, key
+                dataservice, pool_id, pool_name, name, translation_key, key
             )
         )
 
@@ -177,6 +169,7 @@ class AquariteSpeedLabelSensorEntity(AquariteEntity, SensorEntity):
         dataservice: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
+        name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
@@ -184,7 +177,7 @@ class AquariteSpeedLabelSensorEntity(AquariteEntity, SensorEntity):
         super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self) -> str:
@@ -204,6 +197,7 @@ class AquariteIntervalTimeSensorEntity(AquariteEntity, SensorEntity):
         dataservice: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
+        name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
@@ -211,7 +205,7 @@ class AquariteIntervalTimeSensorEntity(AquariteEntity, SensorEntity):
         super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self) -> str | None:
@@ -239,6 +233,7 @@ class AquariteTemperatureSensorEntity(AquariteEntity, SensorEntity):
         dataservice: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
+        name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
@@ -246,7 +241,7 @@ class AquariteTemperatureSensorEntity(AquariteEntity, SensorEntity):
         super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self) -> float | None:
@@ -268,6 +263,7 @@ class AquariteValueSensorEntity(AquariteEntity, SensorEntity):
         dataservice: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
+        name: str,
         translation_key: str,
         value_path: str,
         device_class: SensorDeviceClass | None = None,
@@ -279,7 +275,7 @@ class AquariteValueSensorEntity(AquariteEntity, SensorEntity):
         self._attr_device_class = device_class
         self._attr_native_unit_of_measurement = native_unit_of_measurement
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self) -> float | None:
@@ -299,6 +295,7 @@ class AquariteTimeSensorEntity(AquariteEntity, SensorEntity):
         dataservice: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
+        name: str,
         translation_key: str,
         value_path: str,
         device_class: SensorDeviceClass | None = None,
@@ -310,7 +307,7 @@ class AquariteTimeSensorEntity(AquariteEntity, SensorEntity):
         self._attr_device_class = device_class
         self._attr_native_unit_of_measurement = native_unit_of_measurement
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self) -> float | None:
@@ -333,6 +330,7 @@ class AquariteHydrolyserSensorEntity(AquariteEntity, SensorEntity):
         dataservice: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
+        name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
@@ -340,7 +338,7 @@ class AquariteHydrolyserSensorEntity(AquariteEntity, SensorEntity):
         super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self) -> float | None:
@@ -363,6 +361,7 @@ class AquariteRxValueSensorEntity(AquariteEntity, SensorEntity):
         dataservice: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
+        name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
@@ -370,7 +369,7 @@ class AquariteRxValueSensorEntity(AquariteEntity, SensorEntity):
         super().__init__(dataservice, pool_id, pool_name)
         self._value_path = value_path
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self) -> int | None:
@@ -392,6 +391,7 @@ class AquariteLocationSensorEntity(AquariteEntity, SensorEntity):
         dataservice: AquariteDataUpdateCoordinator,
         pool_id: str,
         pool_name: str,
+        name: str,
         translation_key: str,
         form_key: str,
     ) -> None:
@@ -399,7 +399,7 @@ class AquariteLocationSensorEntity(AquariteEntity, SensorEntity):
         super().__init__(dataservice, pool_id, pool_name)
         self._form_key = form_key
         self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(translation_key)
+        self._attr_unique_id = self.build_unique_id(name)
 
     @property
     def native_value(self) -> str | None:

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -16,19 +16,20 @@ from .entity import AquariteEntity
 class AquariteSwitchConfig:
     """Configuration for an Aquarite switch."""
 
+    name: str
     translation_key: str
     value_path: str
     is_relay: bool = False
 
 
 SWITCH_DEFINITIONS: tuple[AquariteSwitchConfig, ...] = (
-    AquariteSwitchConfig("electrolysis_cover", "hidro.cover_enabled"),
-    AquariteSwitchConfig("electrolysis_boost", "hidro.cloration_enabled"),
-    AquariteSwitchConfig("relay_1", "relays.relay1.info.onoff", is_relay=True),
-    AquariteSwitchConfig("relay_2", "relays.relay2.info.onoff", is_relay=True),
-    AquariteSwitchConfig("relay_3", "relays.relay3.info.onoff", is_relay=True),
-    AquariteSwitchConfig("relay_4", "relays.relay4.info.onoff", is_relay=True),
-    AquariteSwitchConfig("filtration", "filtration.status"),
+    AquariteSwitchConfig("Electrolysis Cover", "electrolysis_cover", "hidro.cover_enabled"),
+    AquariteSwitchConfig("Electrolysis Boost", "electrolysis_boost", "hidro.cloration_enabled"),
+    AquariteSwitchConfig("Relay1", "relay_1", "relays.relay1.info.onoff", is_relay=True),
+    AquariteSwitchConfig("Relay2", "relay_2", "relays.relay2.info.onoff", is_relay=True),
+    AquariteSwitchConfig("Relay3", "relay_3", "relays.relay3.info.onoff", is_relay=True),
+    AquariteSwitchConfig("Relay4", "relay_4", "relays.relay4.info.onoff", is_relay=True),
+    AquariteSwitchConfig("Filtration Status", "filtration", "filtration.status"),
 )
 
 PARALLEL_UPDATES = 1
@@ -64,7 +65,7 @@ class AquariteSwitchEntity(AquariteEntity, SwitchEntity):
         self._value_path = config.value_path
         self._is_relay = config.is_relay
         self._attr_translation_key = config.translation_key
-        self._attr_unique_id = self.build_unique_id(config.translation_key)
+        self._attr_unique_id = self.build_unique_id(config.name, delimiter="")
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
## Summary

The translation_key refactor (PR #54) inadvertently changed all entity unique_ids. For example, a sensor that was `{pool_id}-Temperature` became `{pool_id}-temperature`, and switches that used no delimiter (`{pool_id}Electrolysis Cover`) became `{pool_id}-electrolysis_cover`.

This would cause **all existing entities to be orphaned** on upgrade, losing:
- Entity customizations (names, icons, areas)
- Dashboard cards referencing old entity IDs
- Automations and scripts
- History and statistics

**Fix**: Each entity now takes both a `name` (original format, used for `unique_id`) and a `translation_key` (used for translated display names). The original delimiter conventions are also restored (`-` for sensors/binary_sensors/numbers, empty for switches/selects/light).

## Test plan

- [ ] Upgrade from pre-refactor version — verify all entities keep their existing IDs
- [ ] Verify translated entity names still display correctly
- [ ] Verify automations referencing old entity IDs still work

https://claude.ai/code/session_01LUZiYGpryg1BDvtjmoaC99