### PR TITLE
Expand entity coverage: heating setpoints, cell runtime, RSSI, dosing pumps, firmware

### DIFF
--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -100,6 +100,9 @@ BASE_SENSORS: tuple[AquariteBinarySensorConfig, ...] = (
         "pH Acid Pump", "ph_acid_pump", "modules.ph.pump_high_on", BinarySensorDeviceClass.RUNNING
     ),
     AquariteBinarySensorConfig(
+        "pH Base Pump", "ph_base_pump", "modules.ph.pump_low_on", BinarySensorDeviceClass.RUNNING
+    ),
+    AquariteBinarySensorConfig(
         "Heating Status", "heating_status",
         "relays.filtration.heating.status",
         BinarySensorDeviceClass.RUNNING,
@@ -137,6 +140,30 @@ async def async_setup_entry(
                 AquariteBinarySensorConfig(
                     "Hidro FL2 Status", "hidro_fl2_status",
                     "hidro.fl2", BinarySensorDeviceClass.PROBLEM,
+                ),
+                pool_id,
+                pool_name,
+            )
+        )
+        entities.append(
+            AquariteBinarySensorEntity(
+                dataservice,
+                AquariteBinarySensorConfig(
+                    "Cl Pump Status", "cl_pump_status",
+                    "modules.cl.pump_status", BinarySensorDeviceClass.RUNNING,
+                ),
+                pool_id,
+                pool_name,
+            )
+        )
+
+    if dataservice.get_value(PATH_HASRX):
+        entities.append(
+            AquariteBinarySensorEntity(
+                dataservice,
+                AquariteBinarySensorConfig(
+                    "Rx Pump Status", "rx_pump_status",
+                    "modules.rx.pump_status", BinarySensorDeviceClass.RUNNING,
                 ),
                 pool_id,
                 pool_name,

--- a/custom_components/aquarite/entity.py
+++ b/custom_components/aquarite/entity.py
@@ -23,11 +23,13 @@ class AquariteEntity(CoordinatorEntity[AquariteDataUpdateCoordinator]):
         super().__init__(coordinator)
         self._pool_id = pool_id
         self._pool_name = pool_name
+        sw_version = coordinator.get_value("main.version")
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, pool_id)},
             name=pool_name,
             manufacturer=BRAND,
             model=MODEL,
+            sw_version=str(sw_version) if sw_version else None,
         )
 
     @property

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from typing import Final
 
-from homeassistant.components.number import NumberEntity
-from homeassistant.const import EntityCategory
+from homeassistant.components.number import NumberDeviceClass, NumberEntity
+from homeassistant.const import EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -50,6 +50,18 @@ async def async_setup_entry(
         ),
     ]
 
+    if dataservice.get_value("filtration.hasHeat"):
+        entities.extend([
+            AquariteNumberEntity(
+                dataservice, pool_id, pool_name,
+                5, 40, "Heating Setpoint", "heating_setpoint", "filtration.heating.temp",
+            ),
+            AquariteNumberEntity(
+                dataservice, pool_id, pool_name,
+                5, 40, "Heating High Setpoint", "heating_high_setpoint", "filtration.heating.tempHi",
+            ),
+        ])
+
     async_add_entities(entities)
 
 
@@ -68,6 +80,12 @@ class AquariteNumberEntity(AquariteEntity, NumberEntity):
         "modules.ph.status.low_value": "pH",
         "modules.ph.status.high_value": "pH",
         "hidro.level": "gr/h",
+        "filtration.heating.temp": UnitOfTemperature.CELSIUS,
+        "filtration.heating.tempHi": UnitOfTemperature.CELSIUS,
+    }
+    DEVICE_CLASS_MAP: Final[dict[str, NumberDeviceClass]] = {
+        "filtration.heating.temp": NumberDeviceClass.TEMPERATURE,
+        "filtration.heating.tempHi": NumberDeviceClass.TEMPERATURE,
     }
 
     def __init__(
@@ -89,6 +107,7 @@ class AquariteNumberEntity(AquariteEntity, NumberEntity):
         self._attr_translation_key = translation_key
         self._attr_unique_id = self.build_unique_id(name)
         self._attr_native_unit_of_measurement = self.UNIT_MAP.get(value_path)
+        self._attr_device_class = self.DEVICE_CLASS_MAP.get(value_path)
         self._attr_native_step = self._get_scaled_step()
 
     def _get_scaled_step(self) -> float:

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -7,9 +7,11 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfElectricPotential,
     UnitOfTemperature,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -101,6 +103,21 @@ async def async_setup_entry(
                 dataservice, pool_id, pool_name, name, key, "hidro.current"
             )
         )
+        entities.extend([
+            AquariteCellRuntimeSensorEntity(
+                dataservice, pool_id, pool_name,
+                "Cell Total Time", "cell_total_time", "hidro.cellTotalTime",
+            ),
+            AquariteCellRuntimeSensorEntity(
+                dataservice, pool_id, pool_name,
+                "Cell Partial Time", "cell_partial_time", "hidro.cellPartialTime",
+            ),
+        ])
+
+    # Wi-Fi signal strength (diagnostic, off by default — only useful on Wi-Fi controllers)
+    entities.append(
+        AquariteRssiSensorEntity(dataservice, pool_id, pool_name)
+    )
 
     # Time and Interval Sensors
     entities.append(
@@ -428,3 +445,66 @@ class AquaritePoolNameSensorEntity(AquariteEntity, SensorEntity):
     def native_value(self) -> str:
         """Return the pool name."""
         return self._pool_name
+
+
+class AquariteCellRuntimeSensorEntity(AquariteEntity, SensorEntity):
+    """Electrolysis cell runtime sensor (raw seconds reported as hours)."""
+
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = UnitOfTime.HOURS
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        name: str,
+        translation_key: str,
+        value_path: str,
+    ) -> None:
+        """Initialize the cell runtime sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
+        self._value_path = value_path
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(name)
+
+    @property
+    def native_value(self) -> float | None:
+        """Return runtime in hours, rounded to one decimal."""
+        value = self.coordinator.get_value(self._value_path)
+        try:
+            return round(int(value) / 3600, 1)
+        except (TypeError, ValueError):
+            return None
+
+
+class AquariteRssiSensorEntity(AquariteEntity, SensorEntity):
+    """Controller Wi-Fi signal strength sensor."""
+
+    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+    ) -> None:
+        """Initialize the RSSI sensor."""
+        super().__init__(dataservice, pool_id, pool_name)
+        self._attr_translation_key = "rssi"
+        self._attr_unique_id = self.build_unique_id("RSSI")
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the RSSI value."""
+        value = self.coordinator.get_value("main.RSSI")
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None

--- a/custom_components/aquarite/translations/da.json
+++ b/custom_components/aquarite/translations/da.json
@@ -72,7 +72,10 @@
       "country": { "name": "Land" },
       "latitude": { "name": "Breddegrad" },
       "longitude": { "name": "Længdegrad" },
-      "pool_name": { "name": "Poolnavn" }
+      "pool_name": { "name": "Poolnavn" },
+      "cell_total_time": { "name": "Celle total tid" },
+      "cell_partial_time": { "name": "Celle delvis tid" },
+      "rssi": { "name": "Wi-Fi signalstyrke" }
     },
     "binary_sensor": {
       "hidro_flow_status": { "name": "Hydrolyse flow status" },
@@ -87,6 +90,9 @@
       "io_module_installed": { "name": "IO modul installeret" },
       "hidro_module_installed": { "name": "Hydrolyse modul installeret" },
       "ph_acid_pump": { "name": "pH syrepumpe" },
+      "ph_base_pump": { "name": "pH basepumpe" },
+      "cl_pump_status": { "name": "Klorpumpestatus" },
+      "rx_pump_status": { "name": "Rx pumpestatus" },
       "heating_status": { "name": "Opvarmningsstatus" },
       "filtration_smart_freeze": { "name": "Filtrering smart frost" },
       "connected": { "name": "Forbundet" },
@@ -108,7 +114,9 @@
       "redox_setpoint": { "name": "Redox sætpunkt" },
       "ph_low": { "name": "pH lav" },
       "ph_max": { "name": "pH maks" },
-      "electrolysis_setpoint": { "name": "Elektrolyse sætpunkt" }
+      "electrolysis_setpoint": { "name": "Elektrolyse sætpunkt" },
+      "heating_setpoint": { "name": "Opvarmning sætpunkt" },
+      "heating_high_setpoint": { "name": "Opvarmning højt sætpunkt" }
     },
     "select": {
       "pump_mode": {

--- a/custom_components/aquarite/translations/en.json
+++ b/custom_components/aquarite/translations/en.json
@@ -128,6 +128,15 @@
       },
       "pool_name": {
         "name": "Pool name"
+      },
+      "cell_total_time": {
+        "name": "Cell total time"
+      },
+      "cell_partial_time": {
+        "name": "Cell partial time"
+      },
+      "rssi": {
+        "name": "Wi-Fi signal strength"
       }
     },
     "binary_sensor": {
@@ -166,6 +175,15 @@
       },
       "ph_acid_pump": {
         "name": "pH acid pump"
+      },
+      "ph_base_pump": {
+        "name": "pH base pump"
+      },
+      "cl_pump_status": {
+        "name": "Chlorine pump status"
+      },
+      "rx_pump_status": {
+        "name": "Rx pump status"
       },
       "heating_status": {
         "name": "Heating status"
@@ -224,6 +242,12 @@
       },
       "electrolysis_setpoint": {
         "name": "Electrolysis setpoint"
+      },
+      "heating_setpoint": {
+        "name": "Heating setpoint"
+      },
+      "heating_high_setpoint": {
+        "name": "Heating high setpoint"
       }
     },
     "select": {

--- a/custom_components/aquarite/translations/nl.json
+++ b/custom_components/aquarite/translations/nl.json
@@ -72,7 +72,10 @@
       "country": { "name": "Land" },
       "latitude": { "name": "Breedtegraad" },
       "longitude": { "name": "Lengtegraad" },
-      "pool_name": { "name": "Zwembadnaam" }
+      "pool_name": { "name": "Zwembadnaam" },
+      "cell_total_time": { "name": "Cel totale tijd" },
+      "cell_partial_time": { "name": "Cel deeltijd" },
+      "rssi": { "name": "Wi-Fi signaalsterkte" }
     },
     "binary_sensor": {
       "hidro_flow_status": { "name": "Hydrolyse stroomstatus" },
@@ -87,6 +90,9 @@
       "io_module_installed": { "name": "IO module geïnstalleerd" },
       "hidro_module_installed": { "name": "Hydrolyse module geïnstalleerd" },
       "ph_acid_pump": { "name": "pH zuurpomp" },
+      "ph_base_pump": { "name": "pH basepomp" },
+      "cl_pump_status": { "name": "Chloorpomp status" },
+      "rx_pump_status": { "name": "Rx pomp status" },
       "heating_status": { "name": "Verwarmingsstatus" },
       "filtration_smart_freeze": { "name": "Filtratie smart bevriezing" },
       "connected": { "name": "Verbonden" },
@@ -108,7 +114,9 @@
       "redox_setpoint": { "name": "Redox instelpunt" },
       "ph_low": { "name": "pH laag" },
       "ph_max": { "name": "pH max" },
-      "electrolysis_setpoint": { "name": "Elektrolyse instelpunt" }
+      "electrolysis_setpoint": { "name": "Elektrolyse instelpunt" },
+      "heating_setpoint": { "name": "Verwarming instelpunt" },
+      "heating_high_setpoint": { "name": "Verwarming hoog instelpunt" }
     },
     "select": {
       "pump_mode": {


### PR DESCRIPTION
## Summary
Surface several Firestore fields the integration was already receiving but not yet exposing as entities. Based on a real-world payload review.

### New entities

- **Heating setpoints** (`Number`, gated on `filtration.hasHeat`)
  - `filtration.heating.temp` → "Heating setpoint"
  - `filtration.heating.tempHi` → "Heating high setpoint"
  - Both use `NumberDeviceClass.TEMPERATURE` (°C) so HA renders them properly.
  - This is the first way to *set* the heater target from HA — previously only the binary "Heating Status" sensor was exposed.

- **Electrolysis cell runtime** (`Sensor`, diagnostic, gated on `hasHidro`)
  - `hidro.cellTotalTime` → "Cell total time"
  - `hidro.cellPartialTime` → "Cell partial time"
  - Raw seconds converted to hours, `device_class=duration`, `state_class=total_increasing`. Useful for cell replacement scheduling.

- **Wi-Fi signal strength** (`Sensor`, diagnostic, **disabled by default**)
  - `main.RSSI` → "Wi-Fi signal strength" (dBm).
  - Off by default since it only reports a useful value on Wi-Fi-connected controllers (AWS-only controllers report `0`).

- **Dosing pump symmetry gap** (`BinarySensor`)
  - `modules.ph.pump_low_on` → "pH base pump" (counterpart to the existing "pH acid pump")
  - `modules.cl.pump_status` → "Chlorine pump status" (gated on `hasCL`)
  - `modules.rx.pump_status` → "Rx pump status" (gated on `hasRX`)

### Device info
- `main.version` is now plumbed into `DeviceInfo.sw_version`, so the controller firmware shows up natively under the device card.

### Translations
- `en.json`, `da.json`, `nl.json` all updated for the new entities.

## Notes / things worth verifying on real hardware

1. **Heating setpoint range** — I used `5–40 °C` as a safe range. If Hayward enforces narrower bounds, we can tighten this.
2. **Cell time semantics** — in the snapshot used for design, `cellPartialTime > cellTotalTime`, which is unusual. The fields are exposed using their literal Hayward names; users with cell history can confirm which is the lifetime counter vs. resettable counter.
3. **`hasHeat` gate** — I gate on truthiness (`> 0`). The snapshot showed `hasHeat: 2`, suggesting it may be an enum (e.g. 1 = electric heat, 2 = heat pump). If `0` truly means "no heater", this gate is correct.

## Test plan
- [ ] On a pool with `filtration.hasHeat > 0`: confirm "Heating setpoint" and "Heating high setpoint" appear, render in °C, and writes succeed.
- [ ] On a pool with `hasHidro=1`: confirm cell runtime sensors appear under diagnostics, values look plausible in hours.
- [ ] On a Wi-Fi-connected controller: enable the RSSI sensor in the entity registry and confirm it reports a real dBm value.
- [ ] Confirm "pH base pump", "Chlorine pump status", "Rx pump status" appear when their respective modules are present, and toggle correctly when dosing.
- [ ] Open the device card in HA and confirm the controller firmware version appears next to "Software version".
