### PR TITLE
Mirror per-mode filtration temperature settings + remove cell runtime sensors

### DIFF
--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -108,11 +108,6 @@ BASE_SENSORS: tuple[AquariteBinarySensorConfig, ...] = (
         BinarySensorDeviceClass.RUNNING,
     ),
     AquariteBinarySensorConfig(
-        "Filtration Smart Freeze", "filtration_smart_freeze",
-        "filtration.smart.freeze",
-        BinarySensorDeviceClass.RUNNING,
-    ),
-    AquariteBinarySensorConfig(
         "Connected", "connected", "present", BinarySensorDeviceClass.CONNECTIVITY
     ),
 )

--- a/custom_components/aquarite/icons.json
+++ b/custom_components/aquarite/icons.json
@@ -4,15 +4,6 @@
       "temperature": {
         "default": "mdi:thermometer"
       },
-      "filtration_intel_temperature": {
-        "default": "mdi:thermometer"
-      },
-      "filtration_smart_min_temp": {
-        "default": "mdi:thermometer"
-      },
-      "filtration_smart_high_temp": {
-        "default": "mdi:thermometer"
-      },
       "ph": {
         "default": "mdi:ph"
       },
@@ -126,9 +117,6 @@
       "heating_status": {
         "default": "mdi:radiator"
       },
-      "filtration_smart_freeze": {
-        "default": "mdi:snowflake-alert"
-      },
       "connected": {
         "default": "mdi:cloud-check"
       },
@@ -166,6 +154,12 @@
       },
       "filtration": {
         "default": "mdi:pump"
+      },
+      "heating_climate": {
+        "default": "mdi:weather-partly-cloudy"
+      },
+      "smart_mode_freeze": {
+        "default": "mdi:snowflake-alert"
       }
     },
     "number": {
@@ -180,6 +174,21 @@
       },
       "electrolysis_setpoint": {
         "default": "mdi:flash"
+      },
+      "intel_mode_temperature": {
+        "default": "mdi:thermometer"
+      },
+      "heating_mode_min_temperature": {
+        "default": "mdi:thermometer-low"
+      },
+      "heating_mode_max_temperature": {
+        "default": "mdi:thermometer-high"
+      },
+      "smart_mode_min_temperature": {
+        "default": "mdi:thermometer-low"
+      },
+      "smart_mode_max_temperature": {
+        "default": "mdi:thermometer-high"
       }
     },
     "select": {

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -48,17 +48,43 @@ async def async_setup_entry(
             dataservice, pool_id, pool_name,
             0, max_electrolysis, "Electrolysis Setpoint", "electrolysis_setpoint", "hidro.level",
         ),
+        # INTEL mode target temperature (matches the "Température" field shown
+        # under the INTEL slider position in the Hayward app).
+        AquariteNumberEntity(
+            dataservice, pool_id, pool_name,
+            5, 40, "Intel Mode Temperature", "intel_mode_temperature", "filtration.intel.temp",
+        ),
     ]
 
+    # HEAT mode min/max range (the two arrows under "Température minimale" /
+    # "Température maximale" when the HEAT slider position is selected).
+    # Translation keys are intentionally renamed from PR #62 to clarify they
+    # are bounds, not single setpoints. The Python `name` arguments are kept
+    # unchanged so existing unique_ids are preserved.
     if dataservice.get_value("filtration.hasHeat"):
         entities.extend([
             AquariteNumberEntity(
                 dataservice, pool_id, pool_name,
-                5, 40, "Heating Setpoint", "heating_setpoint", "filtration.heating.temp",
+                5, 40, "Heating Setpoint", "heating_mode_min_temperature", "filtration.heating.temp",
             ),
             AquariteNumberEntity(
                 dataservice, pool_id, pool_name,
-                5, 40, "Heating High Setpoint", "heating_high_setpoint", "filtration.heating.tempHi",
+                5, 40, "Heating High Setpoint", "heating_mode_max_temperature", "filtration.heating.tempHi",
+            ),
+        ])
+
+    # SMART mode min/max range (replaces the read-only sensors that previously
+    # exposed `filtration.smart.tempMin` / `tempHigh` — see PR description for
+    # the breaking-change note).
+    if dataservice.get_value("filtration.hasSmart"):
+        entities.extend([
+            AquariteNumberEntity(
+                dataservice, pool_id, pool_name,
+                5, 40, "Smart Mode Min Temperature", "smart_mode_min_temperature", "filtration.smart.tempMin",
+            ),
+            AquariteNumberEntity(
+                dataservice, pool_id, pool_name,
+                5, 40, "Smart Mode Max Temperature", "smart_mode_max_temperature", "filtration.smart.tempHigh",
             ),
         ])
 
@@ -82,10 +108,16 @@ class AquariteNumberEntity(AquariteEntity, NumberEntity):
         "hidro.level": "gr/h",
         "filtration.heating.temp": UnitOfTemperature.CELSIUS,
         "filtration.heating.tempHi": UnitOfTemperature.CELSIUS,
+        "filtration.intel.temp": UnitOfTemperature.CELSIUS,
+        "filtration.smart.tempMin": UnitOfTemperature.CELSIUS,
+        "filtration.smart.tempHigh": UnitOfTemperature.CELSIUS,
     }
     DEVICE_CLASS_MAP: Final[dict[str, NumberDeviceClass]] = {
         "filtration.heating.temp": NumberDeviceClass.TEMPERATURE,
         "filtration.heating.tempHi": NumberDeviceClass.TEMPERATURE,
+        "filtration.intel.temp": NumberDeviceClass.TEMPERATURE,
+        "filtration.smart.tempMin": NumberDeviceClass.TEMPERATURE,
+        "filtration.smart.tempHigh": NumberDeviceClass.TEMPERATURE,
     }
 
     def __init__(

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfElectricPotential,
     UnitOfTemperature,
-    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -43,18 +42,14 @@ async def async_setup_entry(
 
     entities: list[AquariteEntity] = []
 
-    # Temperature Sensors
-    for name, translation_key, path in (
-        ("Temperature", "temperature", "main.temperature"),
-        ("Filtration Intel Temperature", "filtration_intel_temperature", "filtration.intel.temp"),
-        ("Filtration Smart Min Temp", "filtration_smart_min_temp", "filtration.smart.tempMin"),
-        ("Filtration Smart High Temp", "filtration_smart_high_temp", "filtration.smart.tempHigh"),
-    ):
-        entities.append(
-            AquariteTemperatureSensorEntity(
-                dataservice, pool_id, pool_name, name, translation_key, path
-            )
+    # Pool water temperature (the only read-only temperature; all setpoints
+    # are exposed as Number entities — see number.py)
+    entities.append(
+        AquariteTemperatureSensorEntity(
+            dataservice, pool_id, pool_name,
+            "Temperature", "temperature", "main.temperature",
         )
+    )
 
     # Module Presence Sensors
     if dataservice.get_value(PATH_HASCD):
@@ -103,16 +98,6 @@ async def async_setup_entry(
                 dataservice, pool_id, pool_name, name, key, "hidro.current"
             )
         )
-        entities.extend([
-            AquariteCellRuntimeSensorEntity(
-                dataservice, pool_id, pool_name,
-                "Cell Total Time", "cell_total_time", "hidro.cellTotalTime",
-            ),
-            AquariteCellRuntimeSensorEntity(
-                dataservice, pool_id, pool_name,
-                "Cell Partial Time", "cell_partial_time", "hidro.cellPartialTime",
-            ),
-        ])
 
     # Wi-Fi signal strength (diagnostic, off by default — only useful on Wi-Fi controllers)
     entities.append(
@@ -445,39 +430,6 @@ class AquaritePoolNameSensorEntity(AquariteEntity, SensorEntity):
     def native_value(self) -> str:
         """Return the pool name."""
         return self._pool_name
-
-
-class AquariteCellRuntimeSensorEntity(AquariteEntity, SensorEntity):
-    """Electrolysis cell runtime sensor (raw seconds reported as hours)."""
-
-    _attr_device_class = SensorDeviceClass.DURATION
-    _attr_native_unit_of_measurement = UnitOfTime.HOURS
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
-        name: str,
-        translation_key: str,
-        value_path: str,
-    ) -> None:
-        """Initialize the cell runtime sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
-        self._value_path = value_path
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
-
-    @property
-    def native_value(self) -> float | None:
-        """Return runtime in hours, rounded to one decimal."""
-        value = self.coordinator.get_value(self._value_path)
-        try:
-            return round(int(value) / 3600, 1)
-        except (TypeError, ValueError):
-            return None
 
 
 class AquariteRssiSensorEntity(AquariteEntity, SensorEntity):

--- a/custom_components/aquarite/strings.json
+++ b/custom_components/aquarite/strings.json
@@ -48,15 +48,6 @@
       "temperature": {
         "name": "Temperature"
       },
-      "filtration_intel_temperature": {
-        "name": "Filtration intel temperature"
-      },
-      "filtration_smart_min_temp": {
-        "name": "Filtration smart min temperature"
-      },
-      "filtration_smart_high_temp": {
-        "name": "Filtration smart high temperature"
-      },
       "cd": {
         "name": "CD"
       },
@@ -169,9 +160,6 @@
       },
       "heating_status": {
         "name": "Heating status"
-      },
-      "filtration_smart_freeze": {
-        "name": "Filtration smart freeze"
       },
       "connected": {
         "name": "Connected"

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -44,10 +44,37 @@ async def async_setup_entry(
     dataservice = entry.runtime_data.coordinator
     pool_id, pool_name = dataservice.pool_id, entry.title
 
-    async_add_entities([
+    entities = [
         AquariteSwitchEntity(dataservice, pool_id, pool_name, config)
         for config in SWITCH_DEFINITIONS
-    ])
+    ]
+
+    # HEAT mode "Climat" toggle (visible under the HEAT slider position in
+    # the Hayward app).
+    if dataservice.get_value("filtration.hasHeat"):
+        entities.append(
+            AquariteSwitchEntity(
+                dataservice, pool_id, pool_name,
+                AquariteSwitchConfig(
+                    "Heating Climate", "heating_climate", "filtration.heating.clima",
+                ),
+            )
+        )
+
+    # SMART mode "Antigel" (freeze protection) toggle. Replaces the read-only
+    # binary sensor that previously exposed `filtration.smart.freeze` —
+    # see PR description for the breaking-change note.
+    if dataservice.get_value("filtration.hasSmart"):
+        entities.append(
+            AquariteSwitchEntity(
+                dataservice, pool_id, pool_name,
+                AquariteSwitchConfig(
+                    "Smart Mode Freeze", "smart_mode_freeze", "filtration.smart.freeze",
+                ),
+            )
+        )
+
+    async_add_entities(entities)
 
 
 class AquariteSwitchEntity(AquariteEntity, SwitchEntity):

--- a/custom_components/aquarite/translations/da.json
+++ b/custom_components/aquarite/translations/da.json
@@ -46,9 +46,6 @@
   "entity": {
     "sensor": {
       "temperature": { "name": "Temperatur" },
-      "filtration_intel_temperature": { "name": "Filtrering intel temperatur" },
-      "filtration_smart_min_temp": { "name": "Filtrering smart min temperatur" },
-      "filtration_smart_high_temp": { "name": "Filtrering smart høj temperatur" },
       "cd": { "name": "CD" },
       "cl": { "name": "CL" },
       "ph": { "name": "pH" },
@@ -73,8 +70,6 @@
       "latitude": { "name": "Breddegrad" },
       "longitude": { "name": "Længdegrad" },
       "pool_name": { "name": "Poolnavn" },
-      "cell_total_time": { "name": "Celle total tid" },
-      "cell_partial_time": { "name": "Celle delvis tid" },
       "rssi": { "name": "Wi-Fi signalstyrke" }
     },
     "binary_sensor": {
@@ -94,7 +89,6 @@
       "cl_pump_status": { "name": "Klorpumpestatus" },
       "rx_pump_status": { "name": "Rx pumpestatus" },
       "heating_status": { "name": "Opvarmningsstatus" },
-      "filtration_smart_freeze": { "name": "Filtrering smart frost" },
       "connected": { "name": "Forbundet" },
       "hidro_fl2_status": { "name": "Hydrolyse FL2 status" },
       "acid_tank": { "name": "Syretank" },
@@ -108,15 +102,20 @@
       "relay_2": { "name": "Relæ 2" },
       "relay_3": { "name": "Relæ 3" },
       "relay_4": { "name": "Relæ 4" },
-      "filtration": { "name": "Filtrering" }
+      "filtration": { "name": "Filtrering" },
+      "heating_climate": { "name": "Opvarmning klima" },
+      "smart_mode_freeze": { "name": "Smart frostbeskyttelse" }
     },
     "number": {
       "redox_setpoint": { "name": "Redox sætpunkt" },
       "ph_low": { "name": "pH lav" },
       "ph_max": { "name": "pH maks" },
       "electrolysis_setpoint": { "name": "Elektrolyse sætpunkt" },
-      "heating_setpoint": { "name": "Opvarmning sætpunkt" },
-      "heating_high_setpoint": { "name": "Opvarmning højt sætpunkt" }
+      "intel_mode_temperature": { "name": "Intel tilstand temperatur" },
+      "heating_mode_min_temperature": { "name": "Opvarmning min temperatur" },
+      "heating_mode_max_temperature": { "name": "Opvarmning maks temperatur" },
+      "smart_mode_min_temperature": { "name": "Smart min temperatur" },
+      "smart_mode_max_temperature": { "name": "Smart maks temperatur" }
     },
     "select": {
       "pump_mode": {

--- a/custom_components/aquarite/translations/en.json
+++ b/custom_components/aquarite/translations/en.json
@@ -48,15 +48,6 @@
       "temperature": {
         "name": "Temperature"
       },
-      "filtration_intel_temperature": {
-        "name": "Filtration intel temperature"
-      },
-      "filtration_smart_min_temp": {
-        "name": "Filtration smart min temperature"
-      },
-      "filtration_smart_high_temp": {
-        "name": "Filtration smart high temperature"
-      },
       "cd": {
         "name": "CD"
       },
@@ -129,12 +120,6 @@
       "pool_name": {
         "name": "Pool name"
       },
-      "cell_total_time": {
-        "name": "Cell total time"
-      },
-      "cell_partial_time": {
-        "name": "Cell partial time"
-      },
       "rssi": {
         "name": "Wi-Fi signal strength"
       }
@@ -188,9 +173,6 @@
       "heating_status": {
         "name": "Heating status"
       },
-      "filtration_smart_freeze": {
-        "name": "Filtration smart freeze"
-      },
       "connected": {
         "name": "Connected"
       },
@@ -228,6 +210,12 @@
       },
       "filtration": {
         "name": "Filtration"
+      },
+      "heating_climate": {
+        "name": "Heating climate"
+      },
+      "smart_mode_freeze": {
+        "name": "Smart mode freeze protection"
       }
     },
     "number": {
@@ -243,11 +231,20 @@
       "electrolysis_setpoint": {
         "name": "Electrolysis setpoint"
       },
-      "heating_setpoint": {
-        "name": "Heating setpoint"
+      "intel_mode_temperature": {
+        "name": "Intel mode temperature"
       },
-      "heating_high_setpoint": {
-        "name": "Heating high setpoint"
+      "heating_mode_min_temperature": {
+        "name": "Heating mode min temperature"
+      },
+      "heating_mode_max_temperature": {
+        "name": "Heating mode max temperature"
+      },
+      "smart_mode_min_temperature": {
+        "name": "Smart mode min temperature"
+      },
+      "smart_mode_max_temperature": {
+        "name": "Smart mode max temperature"
       }
     },
     "select": {

--- a/custom_components/aquarite/translations/nl.json
+++ b/custom_components/aquarite/translations/nl.json
@@ -46,9 +46,6 @@
   "entity": {
     "sensor": {
       "temperature": { "name": "Temperatuur" },
-      "filtration_intel_temperature": { "name": "Filtratie intel temperatuur" },
-      "filtration_smart_min_temp": { "name": "Filtratie smart min temperatuur" },
-      "filtration_smart_high_temp": { "name": "Filtratie smart hoge temperatuur" },
       "cd": { "name": "CD" },
       "cl": { "name": "CL" },
       "ph": { "name": "pH" },
@@ -73,8 +70,6 @@
       "latitude": { "name": "Breedtegraad" },
       "longitude": { "name": "Lengtegraad" },
       "pool_name": { "name": "Zwembadnaam" },
-      "cell_total_time": { "name": "Cel totale tijd" },
-      "cell_partial_time": { "name": "Cel deeltijd" },
       "rssi": { "name": "Wi-Fi signaalsterkte" }
     },
     "binary_sensor": {
@@ -94,7 +89,6 @@
       "cl_pump_status": { "name": "Chloorpomp status" },
       "rx_pump_status": { "name": "Rx pomp status" },
       "heating_status": { "name": "Verwarmingsstatus" },
-      "filtration_smart_freeze": { "name": "Filtratie smart bevriezing" },
       "connected": { "name": "Verbonden" },
       "hidro_fl2_status": { "name": "Hydrolyse FL2 status" },
       "acid_tank": { "name": "Zuurtank" },
@@ -108,15 +102,20 @@
       "relay_2": { "name": "Relais 2" },
       "relay_3": { "name": "Relais 3" },
       "relay_4": { "name": "Relais 4" },
-      "filtration": { "name": "Filtratie" }
+      "filtration": { "name": "Filtratie" },
+      "heating_climate": { "name": "Verwarming klimaat" },
+      "smart_mode_freeze": { "name": "Smart vorstbescherming" }
     },
     "number": {
       "redox_setpoint": { "name": "Redox instelpunt" },
       "ph_low": { "name": "pH laag" },
       "ph_max": { "name": "pH max" },
       "electrolysis_setpoint": { "name": "Elektrolyse instelpunt" },
-      "heating_setpoint": { "name": "Verwarming instelpunt" },
-      "heating_high_setpoint": { "name": "Verwarming hoog instelpunt" }
+      "intel_mode_temperature": { "name": "Intel modus temperatuur" },
+      "heating_mode_min_temperature": { "name": "Verwarming min temperatuur" },
+      "heating_mode_max_temperature": { "name": "Verwarming max temperatuur" },
+      "smart_mode_min_temperature": { "name": "Smart min temperatuur" },
+      "smart_mode_max_temperature": { "name": "Smart max temperatuur" }
     },
     "select": {
       "pump_mode": {


### PR DESCRIPTION
## Summary

The Hayward app exposes a different temperature/scheduling sub-tree per pump mode (INTEL / SMART / HEAT), and they all share the same UI slot but live under different Firestore paths. The integration was exposing some of these as **read-only sensors**, others as **misnamed Numbers** (PR #62), and missing a few entirely. This PR makes the model consistent: every temperature the user can set in the app is now a writable `Number` entity in HA, and every mode toggle is a writable `Switch`.

It also removes the `Cell total time` / `Cell partial time` sensors added in PR #62, since their values are nonsensical in practice (`partial > total`) and we have no Hayward documentation to interpret them correctly.

## Field map (for reference)

| Mode | App label | Firestore path | Before this PR | After this PR |
|---|---|---|---|---|
| INTEL | Température | `filtration.intel.temp` | Sensor (read-only) | **Number** |
| INTEL | Temps | `filtration.intel.time` | Sensor | _unchanged (follow-up)_ |
| SMART | Température minimale | `filtration.smart.tempMin` | Sensor (read-only) | **Number** |
| SMART | Température maximale | `filtration.smart.tempHigh` | Sensor (read-only) | **Number** |
| SMART | Antigel | `filtration.smart.freeze` | BinarySensor (read-only) | **Switch** |
| HEAT | Température minimale | `filtration.heating.temp` | Number "Heating setpoint" | **Number "Heating mode min temperature"** (rename) |
| HEAT | Température maximale | `filtration.heating.tempHi` | Number "Heating high setpoint" | **Number "Heating mode max temperature"** (rename) |
| HEAT | Climat | `filtration.heating.clima` | _not exposed_ | **Switch "Heating climate"** |

## Changes by file

- **`sensor.py`** — removed the `filtration.intel.temp`, `filtration.smart.tempMin`, `filtration.smart.tempHigh` entries from the temperature sensors loop (collapsed to just `main.temperature`); removed the `cellTotalTime` / `cellPartialTime` block and the `AquariteCellRuntimeSensorEntity` class; dropped the unused `UnitOfTime` import.
- **`number.py`** — renamed translation keys for the two HEAT-mode Numbers (Python `name` args preserved → unique_ids preserved); added one INTEL-mode Number (unconditional, mirrors how `filtration.intel.temp` was previously a sensor); added two SMART-mode Numbers gated on `filtration.hasSmart`. Extended `UNIT_MAP` and `DEVICE_CLASS_MAP` for all five temperature paths.
- **`switch.py`** — refactored `async_setup_entry` to allow gated additions; added "Heating Climate" gated on `filtration.hasHeat`, "Smart Mode Freeze" gated on `filtration.hasSmart`.
- **`binary_sensor.py`** — removed `filtration_smart_freeze` from `BASE_SENSORS`.
- **`icons.json`** — pruned icons for removed entities, added thermometer/weather/snowflake icons for new entities.
- **`strings.json`** — only the deprecated keys being removed in this PR are pruned (this file has been drifting since before PR #59 — left as-is to avoid scope creep).
- **`translations/{en,da,nl}.json`** — full set of removals and additions for every locale.

## ⚠️ Breaking changes (heads-up for release notes)

Anyone using these in dashboards or automations will need to update their references after upgrading:

| Old (removed) | New (added) |
|---|---|
| `sensor.<pool>_filtration_intel_temperature` | `number.<pool>_intel_mode_temperature` |
| `sensor.<pool>_filtration_smart_min_temp` | `number.<pool>_smart_mode_min_temperature` |
| `sensor.<pool>_filtration_smart_high_temp` | `number.<pool>_smart_mode_max_temperature` |
| `binary_sensor.<pool>_filtration_smart_freeze` | `switch.<pool>_smart_mode_freeze` |
| `sensor.<pool>_cell_total_time` | _removed entirely_ |
| `sensor.<pool>_cell_partial_time` | _removed entirely_ |

Existing entity registry entries for the removed entities will become orphaned and can be cleaned up manually under **Settings → Devices & Services → Entities** (filtered by "Not provided by integration").

The two HEAT-mode Numbers are **renamed only** — entity_ids and unique_ids are preserved (Python `name` args unchanged), so dashboards that reference them keep working. The friendly names update automatically on next reload.

## Test plan

- [ ] On a pool with `filtration.hasHeat > 0`: confirm the heater min/max Numbers now display as "Heating mode min temperature" / "Heating mode max temperature" (no duplicate entities).
- [ ] On a pool with `filtration.hasHeat > 0`: confirm a new "Heating climate" switch appears and toggling it round-trips through the cloud.
- [ ] On a pool with `filtration.hasSmart > 0`: confirm "Smart mode min/max temperature" Numbers appear, render in °C, and writes are persisted.
- [ ] On a pool with `filtration.hasSmart > 0`: confirm "Smart mode freeze protection" switch appears, toggle works.
- [ ] Confirm the new "Intel mode temperature" Number appears and writes work.
- [ ] Confirm the cell total/partial time sensors are gone.
- [ ] Confirm the old smart min/high temp sensors and `filtration_smart_freeze` binary sensor are flagged as "Not provided by integration" and can be removed manually.

## Deferred to a follow-up

- `filtration.intel.time` is still a sensor; the app shows it as tappable so it should logically also become a Number (different unit handling — minutes ↔ hours).
- `strings.json` has drifted from `en.json` for a while (missing several keys added in PRs #59, #60, #62). Worth a separate cleanup PR to resync the file fully if you intend to use it as a translation source.
