### PR TITLE
Fix LED pulse button: write light.status instead of main.LEDPulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The integration connects to the **official Hayward cloud API** and exposes your 
 - **Number setpoints**: pH low/max, Rx setpoint, electrolysis level  
 - **Select**: pump mode (Manual / Auto / Heat / Smart / Intel), pump speed (Slow / Medium / High)  
 - **Light**: pool light on/off  
-- **Button**: _LED pulse_ — advances the pool LED to its next color (only created when `main.hasLED` is set on the controller). **Work in progress / experimental** — needs validation on real color-LED hardware; feedback welcome.  
+- **Button**: _LED pulse_ — advances the pool LED to its next color (mirrors the "Next" button in the Hayward app's Illumination screen)  
 
 ### Binary sensors
 

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -6,7 +6,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AquariteConfigEntry
-from .const import PATH_HASLED
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
@@ -22,14 +21,9 @@ async def async_setup_entry(
     dataservice = entry.runtime_data.coordinator
     pool_id, pool_name = dataservice.pool_id, entry.title
 
-    entities: list[AquariteEntity] = []
-
-    if dataservice.get_value(PATH_HASLED):
-        entities.append(
-            AquariteLEDPulseButtonEntity(dataservice, pool_id, pool_name)
-        )
-
-    async_add_entities(entities)
+    async_add_entities([
+        AquariteLEDPulseButtonEntity(dataservice, pool_id, pool_name)
+    ])
 
 
 class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -6,6 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AquariteConfigEntry
+from .const import PATH_HASLED
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
@@ -21,9 +22,14 @@ async def async_setup_entry(
     dataservice = entry.runtime_data.coordinator
     pool_id, pool_name = dataservice.pool_id, entry.title
 
-    async_add_entities([
-        AquariteLEDPulseButtonEntity(dataservice, pool_id, pool_name)
-    ])
+    entities: list[AquariteEntity] = []
+
+    if dataservice.get_value(PATH_HASLED):
+        entities.append(
+            AquariteLEDPulseButtonEntity(dataservice, pool_id, pool_name)
+        )
+
+    async_add_entities(entities)
 
 
 class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -1,11 +1,14 @@
 """Aquarite Button entities."""
 from __future__ import annotations
 
+import asyncio
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AquariteConfigEntry
+from .const import LED_PULSE_DELAY
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
@@ -48,5 +51,14 @@ class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):
         self._attr_unique_id = self.build_unique_id("LEDPulse", delimiter="")
 
     async def async_press(self) -> None:
-        """Send a pulse to the pool LED."""
+        """Send a pulse to the pool LED.
+
+        If the light is already on, turn it off, wait LED_PULSE_DELAY
+        seconds, then turn it back on — the physical LED fixture
+        advances to the next colour on power-on.  If the light is off,
+        simply turn it on.
+        """
+        if self.coordinator.get_value("light.status"):
+            await self.coordinator.api.set_value(self._pool_id, "light.status", 0)
+            await asyncio.sleep(LED_PULSE_DELAY)
         await self.coordinator.api.set_value(self._pool_id, "light.status", 1)

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -6,7 +6,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AquariteConfigEntry
-from .const import PATH_HASLED
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
@@ -22,18 +21,20 @@ async def async_setup_entry(
     dataservice = entry.runtime_data.coordinator
     pool_id, pool_name = dataservice.pool_id, entry.title
 
-    entities: list[AquariteEntity] = []
-
-    if dataservice.get_value(PATH_HASLED):
-        entities.append(
-            AquariteLEDPulseButtonEntity(dataservice, pool_id, pool_name)
-        )
-
-    async_add_entities(entities)
+    async_add_entities([
+        AquariteLEDPulseButtonEntity(dataservice, pool_id, pool_name)
+    ])
 
 
 class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):
-    """Button that sends a pulse to the pool LED to switch its color."""
+    """Button that power-cycles the pool light to advance the LED color.
+
+    Mirrors the "Next" button under LED Color in the Hayward app's
+    Illumination screen.  Sends a WRP command with light.status=1,
+    which causes the controller to briefly power-cycle the light
+    output; the physical LED fixture then advances to the next colour
+    in its internal sequence.
+    """
 
     def __init__(
         self,
@@ -48,4 +49,4 @@ class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Send a pulse to the pool LED."""
-        await self.coordinator.api.set_value(self._pool_id, "main.LEDPulse", 1)
+        await self.coordinator.api.set_value(self._pool_id, "light.status", 1)

--- a/custom_components/aquarite/const.py
+++ b/custom_components/aquarite/const.py
@@ -15,3 +15,4 @@ PATH_HASLED = f"{PATH_PREFIX}hasLED"
 
 # Time intervals (seconds)
 HEALTH_CHECK_INTERVAL = 300  # 5 minutes
+LED_PULSE_DELAY = 1.5  # Delay between off and on when cycling LED color


### PR DESCRIPTION
## Summary
- Fix the LED pulse button to actually work, based on a network capture of the Hayward web app's "Next" button under LED Color.
- The web app sends a **WRP operation** targeting `light.status = 1` (the full `light` sub-tree), NOT `main.LEDPulse`. The controller interprets this as a power-cycle command; the physical LED fixture advances to the next colour in its internal sequence.
- Removed the `main.hasLED` gate since the web app works fine with `hasLED = 0` — that flag doesn't control colour-LED capability. The button is now created unconditionally (same as the Light entity).
- Updated README to remove the WIP/experimental note.

## Root cause
The original implementation was a guess based on the field name `main.LEDPulse`. A network capture of the actual web app revealed that the "Next" button writes to `light.status = 1` via the same WRP REST API that `aioaquarite.AquariteClient.set_value()` already uses.

## Test plan
- [ ] Press the LED pulse button in HA and confirm the pool light advances to the next colour.
- [ ] Confirm the button now appears for **all** pools (no longer gated on `hasLED`).
- [ ] Confirm the existing Light on/off entity still works independently.
