### PR TITLE
Add user-controllable filtration interval and speed entities

### DIFF
--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -27,6 +27,7 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TIME,
 ]
 
 

--- a/custom_components/aquarite/icons.json
+++ b/custom_components/aquarite/icons.json
@@ -28,33 +28,6 @@
       "filtration_intel_time": {
         "default": "mdi:timer-outline"
       },
-      "filtration_interval_1_from": {
-        "default": "mdi:clock-start"
-      },
-      "filtration_interval_1_to": {
-        "default": "mdi:clock-end"
-      },
-      "filtration_interval_2_from": {
-        "default": "mdi:clock-start"
-      },
-      "filtration_interval_2_to": {
-        "default": "mdi:clock-end"
-      },
-      "filtration_interval_3_from": {
-        "default": "mdi:clock-start"
-      },
-      "filtration_interval_3_to": {
-        "default": "mdi:clock-end"
-      },
-      "filtration_timer_speed_1": {
-        "default": "mdi:speedometer"
-      },
-      "filtration_timer_speed_2": {
-        "default": "mdi:speedometer"
-      },
-      "filtration_timer_speed_3": {
-        "default": "mdi:speedometer"
-      },
       "pool_name": {
         "default": "mdi:pool"
       },
@@ -197,6 +170,35 @@
       },
       "pump_speed": {
         "default": "mdi:speedometer"
+      },
+      "filtration_timer_speed_1": {
+        "default": "mdi:speedometer"
+      },
+      "filtration_timer_speed_2": {
+        "default": "mdi:speedometer"
+      },
+      "filtration_timer_speed_3": {
+        "default": "mdi:speedometer"
+      }
+    },
+    "time": {
+      "filtration_interval_1_from": {
+        "default": "mdi:clock-start"
+      },
+      "filtration_interval_1_to": {
+        "default": "mdi:clock-end"
+      },
+      "filtration_interval_2_from": {
+        "default": "mdi:clock-start"
+      },
+      "filtration_interval_2_to": {
+        "default": "mdi:clock-end"
+      },
+      "filtration_interval_3_from": {
+        "default": "mdi:clock-start"
+      },
+      "filtration_interval_3_to": {
+        "default": "mdi:clock-end"
       }
     },
     "light": {

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -11,6 +11,7 @@ from .entity import AquariteEntity
 
 PUMP_MODE_OPTIONS: tuple[str, ...] = ("Manual", "Auto", "Heat", "Smart", "Intel")
 PUMP_SPEED_OPTIONS: tuple[str, ...] = ("Slow", "Medium", "High")
+TIMER_SPEED_OPTIONS: tuple[str, ...] = ("Slow", "Medium", "High")
 
 PARALLEL_UPDATES = 1
 
@@ -24,7 +25,7 @@ async def async_setup_entry(
     dataservice = entry.runtime_data.coordinator
     pool_id, pool_name = dataservice.pool_id, entry.title
 
-    async_add_entities([
+    entities = [
         AquariteSelectEntity(
             dataservice, pool_id, pool_name,
             "Pump Mode", "pump_mode", "filtration.mode", PUMP_MODE_OPTIONS,
@@ -33,7 +34,20 @@ async def async_setup_entry(
             dataservice, pool_id, pool_name,
             "Pump Speed", "pump_speed", "filtration.manVel", PUMP_SPEED_OPTIONS,
         ),
-    ])
+    ]
+
+    for index in range(1, 4):
+        entities.append(
+            AquariteSelectEntity(
+                dataservice, pool_id, pool_name,
+                f"Filtration Timer Speed {index}",
+                f"filtration_timer_speed_{index}",
+                f"filtration.timerVel{index}",
+                TIMER_SPEED_OPTIONS,
+            )
+        )
+
+    async_add_entities(entities)
 
 
 class AquariteSelectEntity(AquariteEntity, SelectEntity):

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -114,31 +114,6 @@ async def async_setup_entry(
         )
     )
 
-    for name, translation_key, path in (
-        ("Filtration Interval 1 From", "filtration_interval_1_from", "filtration.interval1.from"),
-        ("Filtration Interval 1 To", "filtration_interval_1_to", "filtration.interval1.to"),
-        ("Filtration Interval 2 From", "filtration_interval_2_from", "filtration.interval2.from"),
-        ("Filtration Interval 2 To", "filtration_interval_2_to", "filtration.interval2.to"),
-        ("Filtration Interval 3 From", "filtration_interval_3_from", "filtration.interval3.from"),
-        ("Filtration Interval 3 To", "filtration_interval_3_to", "filtration.interval3.to"),
-    ):
-        entities.append(
-            AquariteIntervalTimeSensorEntity(
-                dataservice, pool_id, pool_name, name, translation_key, path
-            )
-        )
-
-    # Speed sensors
-    for index in range(1, 4):
-        entities.append(
-            AquariteSpeedLabelSensorEntity(
-                dataservice, pool_id, pool_name,
-                f"Filtration Timer Speed {index}",
-                f"filtration_timer_speed_{index}",
-                f"filtration.timerVel{index}",
-            )
-        )
-
     # Location sensors (diagnostic)
     for name, translation_key, key in (
         ("City", "city", "city"),
@@ -159,68 +134,6 @@ async def async_setup_entry(
     )
 
     async_add_entities(entities)
-
-
-class AquariteSpeedLabelSensorEntity(AquariteEntity, SensorEntity):
-    """Speed label sensor entity."""
-
-    SPEED_LABELS: dict[int, str] = {0: "Slow", 1: "Medium", 2: "High"}
-
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
-        name: str,
-        translation_key: str,
-        value_path: str,
-    ) -> None:
-        """Initialize the speed label sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
-        self._value_path = value_path
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
-
-    @property
-    def native_value(self) -> str:
-        """Return the speed label."""
-        value = self.coordinator.get_value(self._value_path)
-        try:
-            return self.SPEED_LABELS.get(int(value), "Unknown")
-        except (ValueError, TypeError):
-            return "Unknown"
-
-
-class AquariteIntervalTimeSensorEntity(AquariteEntity, SensorEntity):
-    """Interval time sensor entity."""
-
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
-        name: str,
-        translation_key: str,
-        value_path: str,
-    ) -> None:
-        """Initialize the interval time sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
-        self._value_path = value_path
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
-
-    @property
-    def native_value(self) -> str | None:
-        """Return the time interval as HH:MM."""
-        raw_value = self.coordinator.get_value(self._value_path)
-        try:
-            seconds = int(raw_value)
-            hours, minutes = seconds // 3600, (seconds % 3600) // 60
-            if hours < 24:
-                return f"{hours:02d}:{minutes:02d}"
-            return f"{hours % 24:02d}:{minutes:02d} (+{hours // 24}d)"
-        except (TypeError, ValueError):
-            return None
 
 
 class AquariteTemperatureSensorEntity(AquariteEntity, SensorEntity):

--- a/custom_components/aquarite/strings.json
+++ b/custom_components/aquarite/strings.json
@@ -72,33 +72,6 @@
       "filtration_intel_time": {
         "name": "Filtration intel time"
       },
-      "filtration_interval_1_from": {
-        "name": "Filtration interval 1 from"
-      },
-      "filtration_interval_1_to": {
-        "name": "Filtration interval 1 to"
-      },
-      "filtration_interval_2_from": {
-        "name": "Filtration interval 2 from"
-      },
-      "filtration_interval_2_to": {
-        "name": "Filtration interval 2 to"
-      },
-      "filtration_interval_3_from": {
-        "name": "Filtration interval 3 from"
-      },
-      "filtration_interval_3_to": {
-        "name": "Filtration interval 3 to"
-      },
-      "filtration_timer_speed_1": {
-        "name": "Filtration timer speed 1"
-      },
-      "filtration_timer_speed_2": {
-        "name": "Filtration timer speed 2"
-      },
-      "filtration_timer_speed_3": {
-        "name": "Filtration timer speed 3"
-      },
       "city": {
         "name": "City"
       },
@@ -232,6 +205,50 @@
           "Medium": "Medium",
           "High": "High"
         }
+      },
+      "filtration_timer_speed_1": {
+        "name": "Filtration timer speed 1",
+        "state": {
+          "Slow": "Slow",
+          "Medium": "Medium",
+          "High": "High"
+        }
+      },
+      "filtration_timer_speed_2": {
+        "name": "Filtration timer speed 2",
+        "state": {
+          "Slow": "Slow",
+          "Medium": "Medium",
+          "High": "High"
+        }
+      },
+      "filtration_timer_speed_3": {
+        "name": "Filtration timer speed 3",
+        "state": {
+          "Slow": "Slow",
+          "Medium": "Medium",
+          "High": "High"
+        }
+      }
+    },
+    "time": {
+      "filtration_interval_1_from": {
+        "name": "Filtration interval 1 from"
+      },
+      "filtration_interval_1_to": {
+        "name": "Filtration interval 1 to"
+      },
+      "filtration_interval_2_from": {
+        "name": "Filtration interval 2 from"
+      },
+      "filtration_interval_2_to": {
+        "name": "Filtration interval 2 to"
+      },
+      "filtration_interval_3_from": {
+        "name": "Filtration interval 3 from"
+      },
+      "filtration_interval_3_to": {
+        "name": "Filtration interval 3 to"
       }
     },
     "light": {

--- a/custom_components/aquarite/time.py
+++ b/custom_components/aquarite/time.py
@@ -1,0 +1,80 @@
+"""Aquarite Time entities for filtration interval control."""
+from __future__ import annotations
+
+import datetime
+
+from homeassistant.components.time import TimeEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import AquariteConfigEntry
+from .coordinator import AquariteDataUpdateCoordinator
+from .entity import AquariteEntity
+
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: AquariteConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Aquarite time entities."""
+    dataservice = entry.runtime_data.coordinator
+    pool_id, pool_name = dataservice.pool_id, entry.title
+
+    entities: list[AquariteTimeEntity] = []
+
+    for name, translation_key, path in (
+        ("Filtration Interval 1 From", "filtration_interval_1_from", "filtration.interval1.from"),
+        ("Filtration Interval 1 To", "filtration_interval_1_to", "filtration.interval1.to"),
+        ("Filtration Interval 2 From", "filtration_interval_2_from", "filtration.interval2.from"),
+        ("Filtration Interval 2 To", "filtration_interval_2_to", "filtration.interval2.to"),
+        ("Filtration Interval 3 From", "filtration_interval_3_from", "filtration.interval3.from"),
+        ("Filtration Interval 3 To", "filtration_interval_3_to", "filtration.interval3.to"),
+    ):
+        entities.append(
+            AquariteTimeEntity(
+                dataservice, pool_id, pool_name, name, translation_key, path,
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class AquariteTimeEntity(AquariteEntity, TimeEntity):
+    """Time entity for filtration interval from/to values."""
+
+    def __init__(
+        self,
+        dataservice: AquariteDataUpdateCoordinator,
+        pool_id: str,
+        pool_name: str,
+        name: str,
+        translation_key: str,
+        value_path: str,
+    ) -> None:
+        """Initialize the time entity."""
+        super().__init__(dataservice, pool_id, pool_name)
+        self._value_path = value_path
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = self.build_unique_id(name)
+
+    @property
+    def native_value(self) -> datetime.time | None:
+        """Return the interval time as a time object."""
+        raw_value = self.coordinator.get_value(self._value_path)
+        try:
+            seconds = int(raw_value)
+            hours = (seconds // 3600) % 24
+            minutes = (seconds % 3600) // 60
+            return datetime.time(hours, minutes)
+        except (TypeError, ValueError):
+            return None
+
+    async def async_set_value(self, value: datetime.time) -> None:
+        """Set the interval time."""
+        seconds = value.hour * 3600 + value.minute * 60
+        await self.coordinator.api.set_value(
+            self._pool_id, self._value_path, seconds,
+        )


### PR DESCRIPTION
## Summary

- **Filtration intervals** (1-3 from/to) converted from read-only sensors to `TimeEntity` with native HA time pickers, allowing users to set filtration schedules directly
- **Timer speeds** (1-3) converted from read-only sensors to `SelectEntity` dropdowns (Slow/Medium/High), allowing users to change pump speed per interval
- Registered `Platform.TIME` and updated `strings.json` / `icons.json` for the new entity types

### Before
9 read-only text sensors displaying times (HH:MM) and speed labels.

### After
6 time pickers + 3 select dropdowns — all user-controllable via the HA UI, writing back to the Hayward API via `api.set_value()`.

### Breaking change
The old `sensor.filtration_interval_*` and `sensor.filtration_timer_speed_*` entities are replaced by `time.*` and `select.*` entities respectively. Existing users will need to remove the stale sensor entities from their entity registry and update any automations referencing them.

## Test plan

- [ ] Verify the 6 time entities appear under the pool device and display the current interval times
- [ ] Change a filtration interval from/to via the time picker and confirm the value is written to the Hayward API
- [ ] Verify the 3 speed select entities appear and show the current speed (Slow/Medium/High)
- [ ] Change a timer speed via the dropdown and confirm it writes correctly
- [ ] Confirm the old sensor entities are no longer created
- [ ] Check icons render correctly for all new entities

https://claude.ai/code/session_01RVHuH5vBjpqhNG7Dfz724q