### PR TITLE
Fix time and select entity names in translation files

### DIFF
--- a/custom_components/aquarite/translations/da.json
+++ b/custom_components/aquarite/translations/da.json
@@ -54,15 +54,6 @@
       "electrolysis": { "name": "Elektrolyse" },
       "hydrolysis": { "name": "Hydrolyse" },
       "filtration_intel_time": { "name": "Filtrering intel tid" },
-      "filtration_interval_1_from": { "name": "Filtrering interval 1 fra" },
-      "filtration_interval_1_to": { "name": "Filtrering interval 1 til" },
-      "filtration_interval_2_from": { "name": "Filtrering interval 2 fra" },
-      "filtration_interval_2_to": { "name": "Filtrering interval 2 til" },
-      "filtration_interval_3_from": { "name": "Filtrering interval 3 fra" },
-      "filtration_interval_3_to": { "name": "Filtrering interval 3 til" },
-      "filtration_timer_speed_1": { "name": "Filtrering timer hastighed 1" },
-      "filtration_timer_speed_2": { "name": "Filtrering timer hastighed 2" },
-      "filtration_timer_speed_3": { "name": "Filtrering timer hastighed 3" },
       "city": { "name": "By" },
       "street": { "name": "Gade" },
       "zipcode": { "name": "Postnummer" },
@@ -135,7 +126,39 @@
           "Medium": "Middel",
           "High": "Høj"
         }
+      },
+      "filtration_timer_speed_1": {
+        "name": "Filtrering timer hastighed 1",
+        "state": {
+          "Slow": "Langsom",
+          "Medium": "Middel",
+          "High": "Høj"
+        }
+      },
+      "filtration_timer_speed_2": {
+        "name": "Filtrering timer hastighed 2",
+        "state": {
+          "Slow": "Langsom",
+          "Medium": "Middel",
+          "High": "Høj"
+        }
+      },
+      "filtration_timer_speed_3": {
+        "name": "Filtrering timer hastighed 3",
+        "state": {
+          "Slow": "Langsom",
+          "Medium": "Middel",
+          "High": "Høj"
+        }
       }
+    },
+    "time": {
+      "filtration_interval_1_from": { "name": "Filtrering interval 1 fra" },
+      "filtration_interval_1_to": { "name": "Filtrering interval 1 til" },
+      "filtration_interval_2_from": { "name": "Filtrering interval 2 fra" },
+      "filtration_interval_2_to": { "name": "Filtrering interval 2 til" },
+      "filtration_interval_3_from": { "name": "Filtrering interval 3 fra" },
+      "filtration_interval_3_to": { "name": "Filtrering interval 3 til" }
     },
     "light": {
       "pool_light": { "name": "Lys" }

--- a/custom_components/aquarite/translations/en.json
+++ b/custom_components/aquarite/translations/en.json
@@ -72,33 +72,6 @@
       "filtration_intel_time": {
         "name": "Filtration intel time"
       },
-      "filtration_interval_1_from": {
-        "name": "Filtration interval 1 from"
-      },
-      "filtration_interval_1_to": {
-        "name": "Filtration interval 1 to"
-      },
-      "filtration_interval_2_from": {
-        "name": "Filtration interval 2 from"
-      },
-      "filtration_interval_2_to": {
-        "name": "Filtration interval 2 to"
-      },
-      "filtration_interval_3_from": {
-        "name": "Filtration interval 3 from"
-      },
-      "filtration_interval_3_to": {
-        "name": "Filtration interval 3 to"
-      },
-      "filtration_timer_speed_1": {
-        "name": "Filtration timer speed 1"
-      },
-      "filtration_timer_speed_2": {
-        "name": "Filtration timer speed 2"
-      },
-      "filtration_timer_speed_3": {
-        "name": "Filtration timer speed 3"
-      },
       "city": {
         "name": "City"
       },
@@ -265,6 +238,50 @@
           "Medium": "Medium",
           "High": "High"
         }
+      },
+      "filtration_timer_speed_1": {
+        "name": "Filtration timer speed 1",
+        "state": {
+          "Slow": "Slow",
+          "Medium": "Medium",
+          "High": "High"
+        }
+      },
+      "filtration_timer_speed_2": {
+        "name": "Filtration timer speed 2",
+        "state": {
+          "Slow": "Slow",
+          "Medium": "Medium",
+          "High": "High"
+        }
+      },
+      "filtration_timer_speed_3": {
+        "name": "Filtration timer speed 3",
+        "state": {
+          "Slow": "Slow",
+          "Medium": "Medium",
+          "High": "High"
+        }
+      }
+    },
+    "time": {
+      "filtration_interval_1_from": {
+        "name": "Filtration interval 1 from"
+      },
+      "filtration_interval_1_to": {
+        "name": "Filtration interval 1 to"
+      },
+      "filtration_interval_2_from": {
+        "name": "Filtration interval 2 from"
+      },
+      "filtration_interval_2_to": {
+        "name": "Filtration interval 2 to"
+      },
+      "filtration_interval_3_from": {
+        "name": "Filtration interval 3 from"
+      },
+      "filtration_interval_3_to": {
+        "name": "Filtration interval 3 to"
       }
     },
     "light": {

--- a/custom_components/aquarite/translations/nl.json
+++ b/custom_components/aquarite/translations/nl.json
@@ -54,15 +54,6 @@
       "electrolysis": { "name": "Elektrolyse" },
       "hydrolysis": { "name": "Hydrolyse" },
       "filtration_intel_time": { "name": "Filtratie intel tijd" },
-      "filtration_interval_1_from": { "name": "Filtratie interval 1 van" },
-      "filtration_interval_1_to": { "name": "Filtratie interval 1 tot" },
-      "filtration_interval_2_from": { "name": "Filtratie interval 2 van" },
-      "filtration_interval_2_to": { "name": "Filtratie interval 2 tot" },
-      "filtration_interval_3_from": { "name": "Filtratie interval 3 van" },
-      "filtration_interval_3_to": { "name": "Filtratie interval 3 tot" },
-      "filtration_timer_speed_1": { "name": "Filtratie timer snelheid 1" },
-      "filtration_timer_speed_2": { "name": "Filtratie timer snelheid 2" },
-      "filtration_timer_speed_3": { "name": "Filtratie timer snelheid 3" },
       "city": { "name": "Stad" },
       "street": { "name": "Straat" },
       "zipcode": { "name": "Postcode" },
@@ -135,7 +126,39 @@
           "Medium": "Gemiddeld",
           "High": "Hoog"
         }
+      },
+      "filtration_timer_speed_1": {
+        "name": "Filtratie timer snelheid 1",
+        "state": {
+          "Slow": "Langzaam",
+          "Medium": "Gemiddeld",
+          "High": "Hoog"
+        }
+      },
+      "filtration_timer_speed_2": {
+        "name": "Filtratie timer snelheid 2",
+        "state": {
+          "Slow": "Langzaam",
+          "Medium": "Gemiddeld",
+          "High": "Hoog"
+        }
+      },
+      "filtration_timer_speed_3": {
+        "name": "Filtratie timer snelheid 3",
+        "state": {
+          "Slow": "Langzaam",
+          "Medium": "Gemiddeld",
+          "High": "Hoog"
+        }
       }
+    },
+    "time": {
+      "filtration_interval_1_from": { "name": "Filtratie interval 1 van" },
+      "filtration_interval_1_to": { "name": "Filtratie interval 1 tot" },
+      "filtration_interval_2_from": { "name": "Filtratie interval 2 van" },
+      "filtration_interval_2_to": { "name": "Filtratie interval 2 tot" },
+      "filtration_interval_3_from": { "name": "Filtratie interval 3 van" },
+      "filtration_interval_3_to": { "name": "Filtratie interval 3 tot" }
     },
     "light": {
       "pool_light": { "name": "Licht" }


### PR DESCRIPTION
## Summary

- Move filtration interval translations from `sensor` to `time` section in all three language files (en, nl, da)
- Move timer speed translations from `sensor` to `select` section with proper `state` translations
- Fixes entity names showing as generic "Pool" and entity IDs registering as `time.pool`, `time.pool_2`, etc.

### Note for existing installations
If you already loaded the integration with the previous version, the stale `time.pool*` entities need to be deleted from the entity registry and the integration reloaded for correct entity IDs to be assigned.

## Test plan

- [ ] Verify time entities register with correct IDs (e.g. `time.pool_filtration_interval_1_from`)
- [ ] Verify time entities display correct friendly names (e.g. "Filtration interval 1 from")
- [ ] Verify select speed entities display correct names and state translations (Slow/Medium/High)
- [ ] Verify nl/da translations render correctly when HA language is set

https://claude.ai/code/session_01RVHuH5vBjpqhNG7Dfz724q