### PR TITLE
Fix time sync to write Unix timestamp to main.localTime

### DIFF
--- a/custom_components/aquarite/coordinator.py
+++ b/custom_components/aquarite/coordinator.py
@@ -120,10 +120,6 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def set_pool_time_to_now(self) -> None:
         """Sync the pool controller clock with the current time."""
         now = dt_util.now()
-        payload = {
-            "day": now.isoweekday(),
-            "hour": now.hour,
-            "min": now.minute,
-        }
-        _LOGGER.info("Syncing pool time to: %s", payload)
-        await self.api.set_value(self.pool_id, "main.time", payload)
+        timestamp = int(now.timestamp())
+        _LOGGER.info("Syncing pool localTime to: %s (%s)", timestamp, now.isoformat())
+        await self.api.set_value(self.pool_id, "main.localTime", timestamp)


### PR DESCRIPTION
## Summary

- Fix `sync_pool_time` service: write a Unix timestamp to `main.localTime` instead of a `{day, hour, min}` dict to `main.time`
- The controller uses `main.localTime` (visible in diagnostics data) — the old `main.time` path doesn't exist in the Firestore document and was silently ignored

### Root cause
The previous code wrote to `main.time` which is not a field the controller reads. The sync appeared to succeed (no error) but had no effect on the pool's clock. The actual time field is `main.localTime`, a Unix timestamp.

## Test plan

- [ ] Run the `sync_pool_time` service and verify the pool controller's clock updates to the correct time
- [ ] Check HA logs for the new log format: `Syncing pool localTime to: <timestamp> (<iso>)`
- [ ] Verify the time matches across HA and the Hayward app

https://claude.ai/code/session_01RVHuH5vBjpqhNG7Dfz724q