### PR TITLE
Modernize integration to match accepted HA core review patterns

### DIFF
--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -7,7 +7,12 @@ import contextlib
 from dataclasses import dataclass, field
 import logging
 
-from aioaquarite import AquariteAuth, AquariteClient, AuthenticationError
+from aioaquarite import (
+    AquariteAuth,
+    AquariteClient,
+    AquariteError,
+    AuthenticationError,
+)
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
@@ -58,14 +63,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> 
         await auth.authenticate()
     except AuthenticationError as err:
         raise ConfigEntryAuthFailed from err
-    except Exception as err:
+    except AquariteError as err:
         raise ConfigEntryNotReady from err
 
     api = AquariteClient(auth)
 
     try:
         pools = await api.get_pools()
-    except Exception as err:
+    except AquariteError as err:
         raise ConfigEntryNotReady from err
 
     if not pools:
@@ -80,7 +85,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> 
         try:
             coordinator.data = await api.fetch_pool_data(pool_id)
             await coordinator.subscribe()
-        except Exception as err:
+        except AquariteError as err:
             for existing in data.coordinators.values():
                 await existing.async_shutdown()
             raise ConfigEntryNotReady from err
@@ -155,7 +160,7 @@ async def _health_check_loop(hass: HomeAssistant, data: AquariteData) -> None:
         except Exception as err:  # noqa: BLE001
             _LOGGER.error("Health check failed, resubscribing all pools: %s", err)
             for coordinator in data.coordinators.values():
-                with contextlib.suppress(Exception):
+                with contextlib.suppress(Exception):  # noqa: BLE001
                     await coordinator.refresh_subscription()
 
 

--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import asyncio
+import contextlib
+from dataclasses import dataclass, field
 import logging
 
 from aioaquarite import AquariteAuth, AquariteClient, AuthenticationError
@@ -13,7 +15,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
+from .const import DOMAIN, HEALTH_CHECK_INTERVAL
 from .coordinator import AquariteDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,84 +34,156 @@ PLATFORMS: list[Platform] = [
 
 
 @dataclass
-class AquariteRuntimeData:
+class AquariteData:
     """Runtime data for the Aquarite integration."""
 
-    coordinator: AquariteDataUpdateCoordinator
     auth: AquariteAuth
+    api: AquariteClient
+    coordinators: dict[str, AquariteDataUpdateCoordinator] = field(default_factory=dict)
+    health_task: asyncio.Task[None] | None = None
+    token_task: asyncio.Task[None] | None = None
 
 
-AquariteConfigEntry = ConfigEntry[AquariteRuntimeData]
+type AquariteConfigEntry = ConfigEntry[AquariteData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> bool:
     """Set up Aquarite from a config entry."""
+    session = async_get_clientsession(hass)
+    auth = AquariteAuth(
+        session, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD]
+    )
+
     try:
-        user_config = entry.data
-        session = async_get_clientsession(hass)
-        pool_id: str = user_config["pool_id"]
-
-        auth = AquariteAuth(
-            session, user_config[CONF_USERNAME], user_config[CONF_PASSWORD]
-        )
         await auth.authenticate()
+    except AuthenticationError as err:
+        raise ConfigEntryAuthFailed from err
+    except Exception as err:
+        raise ConfigEntryNotReady from err
 
-        api = AquariteClient(auth)
+    api = AquariteClient(auth)
 
-        coordinator = AquariteDataUpdateCoordinator(hass, entry, auth, api, pool_id)
+    try:
+        pools = await api.get_pools()
+    except Exception as err:
+        raise ConfigEntryNotReady from err
 
-        # Initial data fetch and subscription
-        coordinator.data = await api.fetch_pool_data(pool_id)
-        await coordinator.subscribe()
+    if not pools:
+        raise ConfigEntryNotReady("No pools found for this account")
 
-        # Start background tasks (token refresh and health check)
-        await coordinator.setup_tasks()
+    data = AquariteData(auth=auth, api=api)
 
-        entry.runtime_data = AquariteRuntimeData(
-            coordinator=coordinator,
-            auth=auth,
+    for pool_id, pool_name in pools.items():
+        coordinator = AquariteDataUpdateCoordinator(
+            hass, entry, auth, api, pool_id, pool_name
         )
+        try:
+            coordinator.data = await api.fetch_pool_data(pool_id)
+            await coordinator.subscribe()
+        except Exception as err:
+            for existing in data.coordinators.values():
+                await existing.async_shutdown()
+            raise ConfigEntryNotReady from err
+        data.coordinators[pool_id] = coordinator
 
-        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    data.token_task = entry.async_create_background_task(
+        hass, _token_refresh_loop(hass, data), "Aquarite token refresh"
+    )
+    data.health_task = entry.async_create_background_task(
+        hass, _health_check_loop(hass, data), "Aquarite health check"
+    )
 
-        async def handle_sync_time(call: ServiceCall) -> None:
-            """Service call to sync pool time for all loaded entries."""
-            for config_entry in hass.config_entries.async_entries(DOMAIN):
-                if config_entry.state is ConfigEntryState.LOADED:
-                    await config_entry.runtime_data.coordinator.set_pool_time_to_now()
+    entry.runtime_data = data
 
-        if not hass.services.has_service(DOMAIN, "sync_pool_time"):
-            hass.services.async_register(DOMAIN, "sync_pool_time", handle_sync_time)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-        def _maybe_remove_service() -> None:
-            """Remove service if this is the last loaded entry."""
-            remaining = [
-                e
-                for e in hass.config_entries.async_entries(DOMAIN)
-                if e.entry_id != entry.entry_id
-                and e.state is ConfigEntryState.LOADED
-            ]
-            if not remaining:
-                hass.services.async_remove(DOMAIN, "sync_pool_time")
+    _async_register_service(hass)
 
-        entry.async_on_unload(_maybe_remove_service)
+    entry.async_on_unload(lambda: _async_maybe_unregister_service(hass, entry))
 
-        return True
-
-    except AuthenticationError as exc:
-        raise ConfigEntryAuthFailed from exc
-    except Exception as exc:
-        _LOGGER.error("Error setting up entry %s: %s", entry.entry_id, exc)
-        raise ConfigEntryNotReady from exc
+    return True
 
 
 async def async_unload_entry(
     hass: HomeAssistant, entry: AquariteConfigEntry
 ) -> bool:
     """Unload Aquarite config entry."""
+    data = entry.runtime_data
+
+    for task in (data.health_task, data.token_task):
+        if task:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
     unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unloaded:
-        await entry.runtime_data.coordinator.async_shutdown()
+        for coordinator in data.coordinators.values():
+            await coordinator.async_shutdown()
 
     return unloaded
+
+
+async def _token_refresh_loop(hass: HomeAssistant, data: AquariteData) -> None:
+    """Refresh the auth token and resubscribe all coordinators on rotation."""
+    retry_delay = 10
+    while not hass.is_stopping:
+        try:
+            if data.auth.is_token_expiring():
+                _LOGGER.debug("Token expiring soon, refreshing")
+                _, refreshed = await data.auth.get_client()
+                if refreshed:
+                    for coordinator in data.coordinators.values():
+                        await coordinator.refresh_subscription()
+            retry_delay = 10
+            await asyncio.sleep(data.auth.calculate_sleep_duration())
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error(
+                "Error maintaining token: %s, retrying in %ss", err, retry_delay
+            )
+            await asyncio.sleep(retry_delay)
+            retry_delay = min(retry_delay * 2, 600)
+
+
+async def _health_check_loop(hass: HomeAssistant, data: AquariteData) -> None:
+    """Periodically verify connectivity and resubscribe all pools on failure."""
+    while not hass.is_stopping:
+        await asyncio.sleep(HEALTH_CHECK_INTERVAL)
+        try:
+            await data.auth.get_client()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error("Health check failed, resubscribing all pools: %s", err)
+            for coordinator in data.coordinators.values():
+                with contextlib.suppress(Exception):
+                    await coordinator.refresh_subscription()
+
+
+def _async_register_service(hass: HomeAssistant) -> None:
+    """Register the sync_pool_time service if not already registered."""
+    if hass.services.has_service(DOMAIN, "sync_pool_time"):
+        return
+
+    async def handle_sync_time(_call: ServiceCall) -> None:
+        """Sync pool time across all loaded entries and pools."""
+        for config_entry in hass.config_entries.async_entries(DOMAIN):
+            if config_entry.state is not ConfigEntryState.LOADED:
+                continue
+            for coordinator in config_entry.runtime_data.coordinators.values():
+                await coordinator.set_pool_time_to_now()
+
+    hass.services.async_register(DOMAIN, "sync_pool_time", handle_sync_time)
+
+
+def _async_maybe_unregister_service(
+    hass: HomeAssistant, unloading_entry: AquariteConfigEntry
+) -> None:
+    """Remove the sync_pool_time service if no other entries remain loaded."""
+    remaining = [
+        e
+        for e in hass.config_entries.async_entries(DOMAIN)
+        if e.entry_id != unloading_entry.entry_id
+        and e.state is ConfigEntryState.LOADED
+    ]
+    if not remaining:
+        hass.services.async_remove(DOMAIN, "sync_pool_time")

--- a/custom_components/aquarite/__init__.py
+++ b/custom_components/aquarite/__init__.py
@@ -55,9 +55,7 @@ type AquariteConfigEntry = ConfigEntry[AquariteData]
 async def async_setup_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> bool:
     """Set up Aquarite from a config entry."""
     session = async_get_clientsession(hass)
-    auth = AquariteAuth(
-        session, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD]
-    )
+    auth = AquariteAuth(session, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD])
 
     try:
         await auth.authenticate()
@@ -109,9 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> 
     return True
 
 
-async def async_unload_entry(
-    hass: HomeAssistant, entry: AquariteConfigEntry
-) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: AquariteConfigEntry) -> bool:
     """Unload Aquarite config entry."""
     data = entry.runtime_data
 
@@ -187,8 +183,7 @@ def _async_maybe_unregister_service(
     remaining = [
         e
         for e in hass.config_entries.async_entries(DOMAIN)
-        if e.entry_id != unloading_entry.entry_id
-        and e.state is ConfigEntryState.LOADED
+        if e.entry_id != unloading_entry.entry_id and e.state is ConfigEntryState.LOADED
     ]
     if not remaining:
         hass.services.async_remove(DOMAIN, "sync_pool_time")

--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AquariteConfigEntry
 from .const import PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX
@@ -204,7 +204,7 @@ def _hidro_low_description(coordinator: AquariteDataUpdateCoordinator) -> Aquari
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Aquarite binary sensors."""
     entities: list[AquariteBinarySensor] = []

--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -31,20 +31,19 @@ TANK_MODULE_PATHS = (
 
 def _bool_path(path: str) -> Callable[[AquariteDataUpdateCoordinator], bool | None]:
     def _fn(coordinator: AquariteDataUpdateCoordinator) -> bool | None:
-        value = coordinator.get_value(path)
-        if value is None:
+        if coordinator.get_value(path) is None:
             return None
-        return bool(value)
+        return coordinator.get_bool(path)
     return _fn
 
 
 def _any_tank_low(coordinator: AquariteDataUpdateCoordinator) -> bool:
-    return any(coordinator.get_value(path) for path in TANK_MODULE_PATHS)
+    return any(coordinator.get_bool(path) for path in TANK_MODULE_PATHS)
 
 
 def _has_tank_module(coordinator: AquariteDataUpdateCoordinator) -> bool:
     return any(
-        coordinator.get_value(path)
+        coordinator.get_bool(path)
         for path in (PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX)
     )
 
@@ -165,21 +164,21 @@ BASE_SENSORS: tuple[AquariteBinarySensorEntityDescription, ...] = (
         translation_key="hidro_fl2_status",
         device_class=BinarySensorDeviceClass.PROBLEM,
         value_fn=_bool_path("hidro.fl2"),
-        exists_fn=lambda c: bool(c.get_value("main.hasCL")),
+        exists_fn=lambda c: c.get_bool("main.hasCL"),
     ),
     AquariteBinarySensorEntityDescription(
         key="cl_pump_status",
         translation_key="cl_pump_status",
         device_class=BinarySensorDeviceClass.RUNNING,
         value_fn=_bool_path("modules.cl.pump_status"),
-        exists_fn=lambda c: bool(c.get_value("main.hasCL")),
+        exists_fn=lambda c: c.get_bool("main.hasCL"),
     ),
     AquariteBinarySensorEntityDescription(
         key="rx_pump_status",
         translation_key="rx_pump_status",
         device_class=BinarySensorDeviceClass.RUNNING,
         value_fn=_bool_path("modules.rx.pump_status"),
-        exists_fn=lambda c: bool(c.get_value(PATH_HASRX)),
+        exists_fn=lambda c: c.get_bool(PATH_HASRX),
     ),
     AquariteBinarySensorEntityDescription(
         key="acid_tank",
@@ -192,7 +191,7 @@ BASE_SENSORS: tuple[AquariteBinarySensorEntityDescription, ...] = (
 
 
 def _hidro_low_description(coordinator: AquariteDataUpdateCoordinator) -> AquariteBinarySensorEntityDescription:
-    is_electrolysis = bool(coordinator.get_value("hidro.is_electrolysis"))
+    is_electrolysis = coordinator.get_bool("hidro.is_electrolysis")
     key = "electrolysis_low" if is_electrolysis else "hydrolysis_low"
     return AquariteBinarySensorEntityDescription(
         key=key,

--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -122,11 +122,8 @@ async def async_setup_entry(
     entities: list[BinarySensorEntity] = []
 
     for dataservice in entry.runtime_data.coordinators.values():
-        pool_id = dataservice.pool_id
-        pool_name = dataservice.pool_name
-
         entities.extend(
-            AquariteBinarySensorEntity(dataservice, config, pool_id, pool_name)
+            AquariteBinarySensorEntity(dataservice, config)
             for config in BASE_SENSORS
         )
 
@@ -138,8 +135,6 @@ async def async_setup_entry(
                         "Hidro FL2 Status", "hidro_fl2_status",
                         "hidro.fl2", BinarySensorDeviceClass.PROBLEM,
                     ),
-                    pool_id,
-                    pool_name,
                 )
             )
             entities.append(
@@ -149,8 +144,6 @@ async def async_setup_entry(
                         "Cl Pump Status", "cl_pump_status",
                         "modules.cl.pump_status", BinarySensorDeviceClass.RUNNING,
                     ),
-                    pool_id,
-                    pool_name,
                 )
             )
 
@@ -162,8 +155,6 @@ async def async_setup_entry(
                         "Rx Pump Status", "rx_pump_status",
                         "modules.rx.pump_status", BinarySensorDeviceClass.RUNNING,
                     ),
-                    pool_id,
-                    pool_name,
                 )
             )
 
@@ -173,7 +164,7 @@ async def async_setup_entry(
         ):
             entities.append(
                 AquariteBinarySensorTankEntity(
-                    dataservice, "Acid Tank", "acid_tank", pool_id, pool_name
+                    dataservice, "Acid Tank", "acid_tank"
                 )
             )
 
@@ -186,8 +177,6 @@ async def async_setup_entry(
                 AquariteBinarySensorConfig(
                     low_name, low_key, "hidro.low", BinarySensorDeviceClass.PROBLEM
                 ),
-                pool_id,
-                pool_name,
             )
         )
 
@@ -201,11 +190,9 @@ class AquariteBinarySensorEntity(AquariteEntity, BinarySensorEntity):
         self,
         dataservice: AquariteDataUpdateCoordinator,
         config: AquariteBinarySensorConfig,
-        pool_id: str,
-        pool_name: str,
     ) -> None:
         """Initialize the binary sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._value_path = config.value_path
         self._attr_device_class = config.device_class
         self._attr_translation_key = config.translation_key
@@ -234,11 +221,9 @@ class AquariteBinarySensorTankEntity(AquariteEntity, BinarySensorEntity):
         dataservice: AquariteDataUpdateCoordinator,
         name: str,
         translation_key: str,
-        pool_id: str,
-        pool_name: str,
     ) -> None:
         """Initialize the tank sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._attr_translation_key = translation_key
         self._attr_unique_id = self.build_unique_id(name)
 

--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -1,9 +1,9 @@
 """Aquarite Binary Sensor entities."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -34,6 +34,7 @@ def _bool_path(path: str) -> Callable[[AquariteDataUpdateCoordinator], bool | No
         if coordinator.get_value(path) is None:
             return None
         return coordinator.get_bool(path)
+
     return _fn
 
 
@@ -190,7 +191,9 @@ BASE_SENSORS: tuple[AquariteBinarySensorEntityDescription, ...] = (
 )
 
 
-def _hidro_low_description(coordinator: AquariteDataUpdateCoordinator) -> AquariteBinarySensorEntityDescription:
+def _hidro_low_description(
+    coordinator: AquariteDataUpdateCoordinator,
+) -> AquariteBinarySensorEntityDescription:
     is_electrolysis = coordinator.get_bool("hidro.is_electrolysis")
     key = "electrolysis_low" if is_electrolysis else "hydrolysis_low"
     return AquariteBinarySensorEntityDescription(

--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -1,11 +1,14 @@
 """Aquarite Binary Sensor entities."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
+    BinarySensorEntityDescription,
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -16,6 +19,8 @@ from .const import PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
+PARALLEL_UPDATES = 0
+
 TANK_MODULE_PATHS = (
     "modules.ph.tank",
     "modules.rx.tank",
@@ -23,94 +28,178 @@ TANK_MODULE_PATHS = (
     "modules.cd.tank",
 )
 
-PARALLEL_UPDATES = 0
+
+def _bool_path(path: str) -> Callable[[AquariteDataUpdateCoordinator], bool | None]:
+    def _fn(coordinator: AquariteDataUpdateCoordinator) -> bool | None:
+        value = coordinator.get_value(path)
+        if value is None:
+            return None
+        return bool(value)
+    return _fn
 
 
-@dataclass(frozen=True)
-class AquariteBinarySensorConfig:
-    """Configuration for an Aquarite binary sensor."""
-
-    name: str
-    translation_key: str
-    value_path: str
-    device_class: BinarySensorDeviceClass | None = None
-    entity_category: EntityCategory | None = None
-    entity_registry_enabled_default: bool = True
+def _any_tank_low(coordinator: AquariteDataUpdateCoordinator) -> bool:
+    return any(coordinator.get_value(path) for path in TANK_MODULE_PATHS)
 
 
-BASE_SENSORS: tuple[AquariteBinarySensorConfig, ...] = (
-    AquariteBinarySensorConfig(
-        "Hidro Flow Status", "hidro_flow_status", "hidro.fl1", BinarySensorDeviceClass.PROBLEM
+def _has_tank_module(coordinator: AquariteDataUpdateCoordinator) -> bool:
+    return any(
+        coordinator.get_value(path)
+        for path in (PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX)
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class AquariteBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes an Aquarite binary sensor."""
+
+    value_fn: Callable[[AquariteDataUpdateCoordinator], bool | None]
+    exists_fn: Callable[[AquariteDataUpdateCoordinator], bool] | None = None
+
+
+BASE_SENSORS: tuple[AquariteBinarySensorEntityDescription, ...] = (
+    AquariteBinarySensorEntityDescription(
+        key="hidro_flow_status",
+        translation_key="hidro_flow_status",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        value_fn=_bool_path("hidro.fl1"),
     ),
-    AquariteBinarySensorConfig(
-        "Filtration Status", "filtration_status", "filtration.status", BinarySensorDeviceClass.RUNNING
+    AquariteBinarySensorEntityDescription(
+        key="filtration_status",
+        translation_key="filtration_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_fn=_bool_path("filtration.status"),
     ),
-    AquariteBinarySensorConfig(
-        "Backwash Status", "backwash_status", "backwash.status", BinarySensorDeviceClass.RUNNING
+    AquariteBinarySensorEntityDescription(
+        key="backwash_status",
+        translation_key="backwash_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_fn=_bool_path("backwash.status"),
     ),
-    AquariteBinarySensorConfig(
-        "Hidro Cover Reduction", "hidro_cover_reduction", "hidro.cover", BinarySensorDeviceClass.RUNNING
+    AquariteBinarySensorEntityDescription(
+        key="hidro_cover_reduction",
+        translation_key="hidro_cover_reduction",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_fn=_bool_path("hidro.cover"),
     ),
-    AquariteBinarySensorConfig(
-        "pH Pump Alarm", "ph_pump_alarm", "modules.ph.al3", BinarySensorDeviceClass.PROBLEM
+    AquariteBinarySensorEntityDescription(
+        key="ph_pump_alarm",
+        translation_key="ph_pump_alarm",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        value_fn=_bool_path("modules.ph.al3"),
     ),
-    AquariteBinarySensorConfig(
-        "CD Module Installed", "cd_module_installed",
-        "main.hasCD",
-        BinarySensorDeviceClass.CONNECTIVITY,
+    AquariteBinarySensorEntityDescription(
+        key="cd_module_installed",
+        translation_key="cd_module_installed",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=_bool_path("main.hasCD"),
     ),
-    AquariteBinarySensorConfig(
-        "CL Module Installed", "cl_module_installed",
-        "main.hasCL",
-        BinarySensorDeviceClass.CONNECTIVITY,
+    AquariteBinarySensorEntityDescription(
+        key="cl_module_installed",
+        translation_key="cl_module_installed",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=_bool_path("main.hasCL"),
     ),
-    AquariteBinarySensorConfig(
-        "RX Module Installed", "rx_module_installed",
-        "main.hasRX",
-        BinarySensorDeviceClass.CONNECTIVITY,
+    AquariteBinarySensorEntityDescription(
+        key="rx_module_installed",
+        translation_key="rx_module_installed",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=_bool_path("main.hasRX"),
     ),
-    AquariteBinarySensorConfig(
-        "pH Module Installed", "ph_module_installed",
-        "main.hasPH",
-        BinarySensorDeviceClass.CONNECTIVITY,
+    AquariteBinarySensorEntityDescription(
+        key="ph_module_installed",
+        translation_key="ph_module_installed",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=_bool_path("main.hasPH"),
     ),
-    AquariteBinarySensorConfig(
-        "IO Module Installed", "io_module_installed",
-        "main.hasIO",
-        BinarySensorDeviceClass.CONNECTIVITY,
+    AquariteBinarySensorEntityDescription(
+        key="io_module_installed",
+        translation_key="io_module_installed",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=_bool_path("main.hasIO"),
     ),
-    AquariteBinarySensorConfig(
-        "Hidro Module Installed", "hidro_module_installed",
-        "main.hasHidro",
-        BinarySensorDeviceClass.CONNECTIVITY,
+    AquariteBinarySensorEntityDescription(
+        key="hidro_module_installed",
+        translation_key="hidro_module_installed",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=_bool_path("main.hasHidro"),
     ),
-    AquariteBinarySensorConfig(
-        "pH Acid Pump", "ph_acid_pump", "modules.ph.pump_high_on", BinarySensorDeviceClass.RUNNING
+    AquariteBinarySensorEntityDescription(
+        key="ph_acid_pump",
+        translation_key="ph_acid_pump",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_fn=_bool_path("modules.ph.pump_high_on"),
     ),
-    AquariteBinarySensorConfig(
-        "pH Base Pump", "ph_base_pump", "modules.ph.pump_low_on", BinarySensorDeviceClass.RUNNING
+    AquariteBinarySensorEntityDescription(
+        key="ph_base_pump",
+        translation_key="ph_base_pump",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_fn=_bool_path("modules.ph.pump_low_on"),
     ),
-    AquariteBinarySensorConfig(
-        "Heating Status", "heating_status",
-        "relays.filtration.heating.status",
-        BinarySensorDeviceClass.RUNNING,
+    AquariteBinarySensorEntityDescription(
+        key="heating_status",
+        translation_key="heating_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_fn=_bool_path("relays.filtration.heating.status"),
     ),
-    AquariteBinarySensorConfig(
-        "Connected", "connected", "present", BinarySensorDeviceClass.CONNECTIVITY
+    AquariteBinarySensorEntityDescription(
+        key="connected",
+        translation_key="connected",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        value_fn=_bool_path("present"),
+    ),
+    AquariteBinarySensorEntityDescription(
+        key="hidro_fl2_status",
+        translation_key="hidro_fl2_status",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        value_fn=_bool_path("hidro.fl2"),
+        exists_fn=lambda c: bool(c.get_value("main.hasCL")),
+    ),
+    AquariteBinarySensorEntityDescription(
+        key="cl_pump_status",
+        translation_key="cl_pump_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_fn=_bool_path("modules.cl.pump_status"),
+        exists_fn=lambda c: bool(c.get_value("main.hasCL")),
+    ),
+    AquariteBinarySensorEntityDescription(
+        key="rx_pump_status",
+        translation_key="rx_pump_status",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_fn=_bool_path("modules.rx.pump_status"),
+        exists_fn=lambda c: bool(c.get_value(PATH_HASRX)),
+    ),
+    AquariteBinarySensorEntityDescription(
+        key="acid_tank",
+        translation_key="acid_tank",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        value_fn=_any_tank_low,
+        exists_fn=_has_tank_module,
     ),
 )
+
+
+def _hidro_low_description(coordinator: AquariteDataUpdateCoordinator) -> AquariteBinarySensorEntityDescription:
+    is_electrolysis = bool(coordinator.get_value("hidro.is_electrolysis"))
+    key = "electrolysis_low" if is_electrolysis else "hydrolysis_low"
+    return AquariteBinarySensorEntityDescription(
+        key=key,
+        translation_key=key,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        value_fn=_bool_path("hidro.low"),
+    )
 
 
 async def async_setup_entry(
@@ -119,117 +208,37 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Aquarite binary sensors."""
-    entities: list[BinarySensorEntity] = []
+    entities: list[AquariteBinarySensor] = []
 
-    for dataservice in entry.runtime_data.coordinators.values():
+    for coordinator in entry.runtime_data.coordinators.values():
         entities.extend(
-            AquariteBinarySensorEntity(dataservice, config)
-            for config in BASE_SENSORS
+            AquariteBinarySensor(coordinator, description)
+            for description in BASE_SENSORS
+            if description.exists_fn is None or description.exists_fn(coordinator)
         )
-
-        if dataservice.get_value("main.hasCL"):
-            entities.append(
-                AquariteBinarySensorEntity(
-                    dataservice,
-                    AquariteBinarySensorConfig(
-                        "Hidro FL2 Status", "hidro_fl2_status",
-                        "hidro.fl2", BinarySensorDeviceClass.PROBLEM,
-                    ),
-                )
-            )
-            entities.append(
-                AquariteBinarySensorEntity(
-                    dataservice,
-                    AquariteBinarySensorConfig(
-                        "Cl Pump Status", "cl_pump_status",
-                        "modules.cl.pump_status", BinarySensorDeviceClass.RUNNING,
-                    ),
-                )
-            )
-
-        if dataservice.get_value(PATH_HASRX):
-            entities.append(
-                AquariteBinarySensorEntity(
-                    dataservice,
-                    AquariteBinarySensorConfig(
-                        "Rx Pump Status", "rx_pump_status",
-                        "modules.rx.pump_status", BinarySensorDeviceClass.RUNNING,
-                    ),
-                )
-            )
-
-        if any(
-            dataservice.get_value(path)
-            for path in (PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX)
-        ):
-            entities.append(
-                AquariteBinarySensorTankEntity(
-                    dataservice, "Acid Tank", "acid_tank"
-                )
-            )
-
-        is_electrolysis = dataservice.get_value("hidro.is_electrolysis")
-        low_name = "Electrolysis Low" if is_electrolysis else "Hidrolysis Low"
-        low_key = "electrolysis_low" if is_electrolysis else "hydrolysis_low"
         entities.append(
-            AquariteBinarySensorEntity(
-                dataservice,
-                AquariteBinarySensorConfig(
-                    low_name, low_key, "hidro.low", BinarySensorDeviceClass.PROBLEM
-                ),
-            )
+            AquariteBinarySensor(coordinator, _hidro_low_description(coordinator))
         )
 
     async_add_entities(entities)
 
 
-class AquariteBinarySensorEntity(AquariteEntity, BinarySensorEntity):
-    """Representation of an Aquarite binary sensor."""
+class AquariteBinarySensor(AquariteEntity, BinarySensorEntity):
+    """Aquarite binary sensor entity."""
+
+    entity_description: AquariteBinarySensorEntityDescription
 
     def __init__(
         self,
-        dataservice: AquariteDataUpdateCoordinator,
-        config: AquariteBinarySensorConfig,
+        coordinator: AquariteDataUpdateCoordinator,
+        description: AquariteBinarySensorEntityDescription,
     ) -> None:
         """Initialize the binary sensor."""
-        super().__init__(dataservice)
-        self._value_path = config.value_path
-        self._attr_device_class = config.device_class
-        self._attr_translation_key = config.translation_key
-        self._attr_unique_id = self.build_unique_id(config.name)
-        if config.entity_category is not None:
-            self._attr_entity_category = config.entity_category
-        if not config.entity_registry_enabled_default:
-            self._attr_entity_registry_enabled_default = False
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = self.build_unique_id(description.key)
 
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        value = self.coordinator.get_value(self._value_path)
-        if value is None:
-            return None
-        return bool(value)
-
-
-class AquariteBinarySensorTankEntity(AquariteEntity, BinarySensorEntity):
-    """Tank level binary sensor."""
-
-    _attr_device_class = BinarySensorDeviceClass.PROBLEM
-
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        name: str,
-        translation_key: str,
-    ) -> None:
-        """Initialize the tank sensor."""
-        super().__init__(dataservice)
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if any tank is low."""
-        return any(
-            self.coordinator.get_value(module) for module in TANK_MODULE_PATHS
-        )
+        return self.entity_description.value_fn(self.coordinator)

--- a/custom_components/aquarite/binary_sensor.py
+++ b/custom_components/aquarite/binary_sensor.py
@@ -119,75 +119,77 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Aquarite binary sensors."""
-    dataservice = entry.runtime_data.coordinator
-    pool_id = dataservice.pool_id
-    pool_name = entry.title
+    entities: list[BinarySensorEntity] = []
 
-    entities: list[BinarySensorEntity] = [
-        AquariteBinarySensorEntity(dataservice, config, pool_id, pool_name)
-        for config in BASE_SENSORS
-    ]
+    for dataservice in entry.runtime_data.coordinators.values():
+        pool_id = dataservice.pool_id
+        pool_name = dataservice.pool_name
 
-    if dataservice.get_value("main.hasCL"):
+        entities.extend(
+            AquariteBinarySensorEntity(dataservice, config, pool_id, pool_name)
+            for config in BASE_SENSORS
+        )
+
+        if dataservice.get_value("main.hasCL"):
+            entities.append(
+                AquariteBinarySensorEntity(
+                    dataservice,
+                    AquariteBinarySensorConfig(
+                        "Hidro FL2 Status", "hidro_fl2_status",
+                        "hidro.fl2", BinarySensorDeviceClass.PROBLEM,
+                    ),
+                    pool_id,
+                    pool_name,
+                )
+            )
+            entities.append(
+                AquariteBinarySensorEntity(
+                    dataservice,
+                    AquariteBinarySensorConfig(
+                        "Cl Pump Status", "cl_pump_status",
+                        "modules.cl.pump_status", BinarySensorDeviceClass.RUNNING,
+                    ),
+                    pool_id,
+                    pool_name,
+                )
+            )
+
+        if dataservice.get_value(PATH_HASRX):
+            entities.append(
+                AquariteBinarySensorEntity(
+                    dataservice,
+                    AquariteBinarySensorConfig(
+                        "Rx Pump Status", "rx_pump_status",
+                        "modules.rx.pump_status", BinarySensorDeviceClass.RUNNING,
+                    ),
+                    pool_id,
+                    pool_name,
+                )
+            )
+
+        if any(
+            dataservice.get_value(path)
+            for path in (PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX)
+        ):
+            entities.append(
+                AquariteBinarySensorTankEntity(
+                    dataservice, "Acid Tank", "acid_tank", pool_id, pool_name
+                )
+            )
+
+        is_electrolysis = dataservice.get_value("hidro.is_electrolysis")
+        low_name = "Electrolysis Low" if is_electrolysis else "Hidrolysis Low"
+        low_key = "electrolysis_low" if is_electrolysis else "hydrolysis_low"
         entities.append(
             AquariteBinarySensorEntity(
                 dataservice,
                 AquariteBinarySensorConfig(
-                    "Hidro FL2 Status", "hidro_fl2_status",
-                    "hidro.fl2", BinarySensorDeviceClass.PROBLEM,
+                    low_name, low_key, "hidro.low", BinarySensorDeviceClass.PROBLEM
                 ),
                 pool_id,
                 pool_name,
             )
         )
-        entities.append(
-            AquariteBinarySensorEntity(
-                dataservice,
-                AquariteBinarySensorConfig(
-                    "Cl Pump Status", "cl_pump_status",
-                    "modules.cl.pump_status", BinarySensorDeviceClass.RUNNING,
-                ),
-                pool_id,
-                pool_name,
-            )
-        )
-
-    if dataservice.get_value(PATH_HASRX):
-        entities.append(
-            AquariteBinarySensorEntity(
-                dataservice,
-                AquariteBinarySensorConfig(
-                    "Rx Pump Status", "rx_pump_status",
-                    "modules.rx.pump_status", BinarySensorDeviceClass.RUNNING,
-                ),
-                pool_id,
-                pool_name,
-            )
-        )
-
-    if any(
-        dataservice.get_value(path)
-        for path in (PATH_HASCD, PATH_HASCL, PATH_HASPH, PATH_HASRX)
-    ):
-        entities.append(
-            AquariteBinarySensorTankEntity(
-                dataservice, "Acid Tank", "acid_tank", pool_id, pool_name
-            )
-        )
-
-    is_electrolysis = dataservice.get_value("hidro.is_electrolysis")
-    low_name = "Electrolysis Low" if is_electrolysis else "Hidrolysis Low"
-    low_key = "electrolysis_low" if is_electrolysis else "hydrolysis_low"
-    entities.append(
-        AquariteBinarySensorEntity(
-            dataservice,
-            AquariteBinarySensorConfig(
-                low_name, low_key, "hidro.low", BinarySensorDeviceClass.PROBLEM
-            ),
-            pool_id,
-            pool_name,
-        )
-    )
 
     async_add_entities(entities)
 

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -55,7 +55,7 @@ class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):
         simply turn it on.
         """
         try:
-            if self.coordinator.get_value("light.status"):
+            if self.coordinator.get_bool("light.status"):
                 await self.coordinator.api.set_value(
                     self.coordinator.pool_id, "light.status", 0
                 )

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import asyncio
 
+from aioaquarite import AquariteError
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -63,7 +65,7 @@ class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):
             await self.coordinator.api.set_value(
                 self.coordinator.pool_id, "light.status", 1
             )
-        except Exception as err:
+        except AquariteError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -6,7 +6,7 @@ import asyncio
 from homeassistant.components.button import ButtonEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AquariteConfigEntry
 from .const import DOMAIN, LED_PULSE_DELAY, PATH_HASLED
@@ -19,13 +19,13 @@ PARALLEL_UPDATES = 1
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Aquarite button platform."""
     async_add_entities(
         AquariteLEDPulseButtonEntity(dataservice)
         for dataservice in entry.runtime_data.coordinators.values()
-        if dataservice.get_value(PATH_HASLED)
+        if dataservice.get_bool(PATH_HASLED)
     )
 
 

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -23,9 +23,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Aquarite button platform."""
     async_add_entities(
-        AquariteLEDPulseButtonEntity(
-            dataservice, dataservice.pool_id, dataservice.pool_name
-        )
+        AquariteLEDPulseButtonEntity(dataservice)
         for dataservice in entry.runtime_data.coordinators.values()
         if dataservice.get_value(PATH_HASLED)
     )
@@ -41,15 +39,11 @@ class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):
     in its internal sequence.
     """
 
-    def __init__(
-        self,
-        coordinator: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
-    ) -> None:
+    _attr_translation_key = "led_pulse"
+
+    def __init__(self, coordinator: AquariteDataUpdateCoordinator) -> None:
         """Initialize the LED pulse button."""
-        super().__init__(coordinator, pool_id, pool_name)
-        self._attr_translation_key = "led_pulse"
+        super().__init__(coordinator)
         self._attr_unique_id = self.build_unique_id("LEDPulse")
 
     async def async_press(self) -> None:
@@ -62,8 +56,12 @@ class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):
         """
         try:
             if self.coordinator.get_value("light.status"):
-                await self.coordinator.api.set_value(self._pool_id, "light.status", 0)
+                await self.coordinator.api.set_value(
+                    self.coordinator.pool_id, "light.status", 0
+                )
                 await asyncio.sleep(LED_PULSE_DELAY)
-            await self.coordinator.api.set_value(self._pool_id, "light.status", 1)
+            await self.coordinator.api.set_value(
+                self.coordinator.pool_id, "light.status", 1
+            )
         except Exception as err:
             raise HomeAssistantError(f"Failed to pulse LED: {err}") from err

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -44,7 +44,7 @@ class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):
     def __init__(self, coordinator: AquariteDataUpdateCoordinator) -> None:
         """Initialize the LED pulse button."""
         super().__init__(coordinator)
-        self._attr_unique_id = self.build_unique_id("LEDPulse")
+        self._attr_unique_id = self.build_unique_id("led_pulse")
 
     async def async_press(self) -> None:
         """Send a pulse to the pool LED.

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -1,4 +1,5 @@
 """Aquarite Button entities."""
+
 from __future__ import annotations
 
 import asyncio

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -9,7 +9,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AquariteConfigEntry
-from .const import LED_PULSE_DELAY, PATH_HASLED
+from .const import DOMAIN, LED_PULSE_DELAY, PATH_HASLED
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
@@ -64,4 +64,8 @@ class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):
                 self.coordinator.pool_id, "light.status", 1
             )
         except Exception as err:
-            raise HomeAssistantError(f"Failed to pulse LED: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/custom_components/aquarite/button.py
+++ b/custom_components/aquarite/button.py
@@ -22,15 +22,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Aquarite button platform."""
-    dataservice = entry.runtime_data.coordinator
-    pool_id, pool_name = dataservice.pool_id, entry.title
-
-    if not dataservice.get_value(PATH_HASLED):
-        return
-
-    async_add_entities([
-        AquariteLEDPulseButtonEntity(dataservice, pool_id, pool_name)
-    ])
+    async_add_entities(
+        AquariteLEDPulseButtonEntity(
+            dataservice, dataservice.pool_id, dataservice.pool_name
+        )
+        for dataservice in entry.runtime_data.coordinators.values()
+        if dataservice.get_value(PATH_HASLED)
+    )
 
 
 class AquariteLEDPulseButtonEntity(AquariteEntity, ButtonEntity):

--- a/custom_components/aquarite/config_flow.py
+++ b/custom_components/aquarite/config_flow.py
@@ -39,7 +39,7 @@ class AquariteConfigFlow(ConfigFlow, domain=DOMAIN):
             await auth.authenticate()
         except AuthenticationError:
             return "invalid_auth"
-        except Exception:
+        except Exception:  # noqa: BLE001
             _LOGGER.exception("Unexpected error during authentication")
             return "unknown"
         return None

--- a/custom_components/aquarite/config_flow.py
+++ b/custom_components/aquarite/config_flow.py
@@ -1,4 +1,5 @@
 """Config Flow for the Aquarite integration."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping
@@ -29,9 +30,7 @@ USER_SCHEMA = vol.Schema(
 class AquariteConfigFlow(ConfigFlow, domain=DOMAIN):
     """Aquarite config flow."""
 
-    async def _async_validate(
-        self, username: str, password: str
-    ) -> str | None:
+    async def _async_validate(self, username: str, password: str) -> str | None:
         """Validate credentials. Returns an error key, or None on success."""
         session = async_get_clientsession(self.hass)
         auth = AquariteAuth(session, username, password)

--- a/custom_components/aquarite/config_flow.py
+++ b/custom_components/aquarite/config_flow.py
@@ -2,25 +2,23 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import logging
 from typing import Any
 
 import voluptuous as vol
 
-from aioaquarite import AquariteAuth, AquariteClient, AuthenticationError
+from aioaquarite import AquariteAuth, AuthenticationError
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    ConfigFlowResult,
-    OptionsFlow,
-)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
-from .const import CONF_HEALTH_CHECK_INTERVAL, DEFAULT_HEALTH_CHECK_INTERVAL, DOMAIN
+from .const import DOMAIN
 
-AUTH_SCHEMA = vol.Schema(
+_LOGGER = logging.getLogger(__name__)
+
+USER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
@@ -28,110 +26,43 @@ AUTH_SCHEMA = vol.Schema(
 )
 
 
-class AquariteOptionsFlow(OptionsFlow):
-    """Options flow for Aquarite."""
-
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle the options form."""
-        if user_input is not None:
-            return self.async_create_entry(data=user_input)
-
-        current = self.config_entry.options.get(
-            CONF_HEALTH_CHECK_INTERVAL, DEFAULT_HEALTH_CHECK_INTERVAL
-        )
-        schema = vol.Schema(
-            {
-                vol.Required(
-                    CONF_HEALTH_CHECK_INTERVAL, default=current
-                ): vol.All(int, vol.Range(min=60, max=3600)),
-            }
-        )
-        return self.async_show_form(step_id="init", data_schema=schema)
-
-
 class AquariteConfigFlow(ConfigFlow, domain=DOMAIN):
     """Aquarite config flow."""
 
-    @staticmethod
-    def async_get_options_flow(
-        config_entry: ConfigEntry,
-    ) -> AquariteOptionsFlow:
-        """Return the options flow handler."""
-        return AquariteOptionsFlow()
-
-    def __init__(self) -> None:
-        """Initialize the config flow."""
-        self._user_data: dict[str, Any] = {}
-        self._available_pools: dict[str, str] = {}
+    async def _async_validate(
+        self, username: str, password: str
+    ) -> str | None:
+        """Validate credentials. Returns an error key, or None on success."""
+        session = async_get_clientsession(self.hass)
+        auth = AquariteAuth(session, username, password)
+        try:
+            await auth.authenticate()
+        except AuthenticationError:
+            return "invalid_auth"
+        except Exception:
+            _LOGGER.exception("Unexpected error during authentication")
+            return "unknown"
+        return None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
+        errors: dict[str, str] = {}
+
         if user_input is not None:
-            self._user_data = {
-                CONF_USERNAME: user_input[CONF_USERNAME],
-                CONF_PASSWORD: user_input[CONF_PASSWORD],
-            }
-            return await self.async_step_pool()
-
-        return self.async_show_form(step_id="user", data_schema=AUTH_SCHEMA)
-
-    async def async_step_pool(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle the pool selection step."""
-        if user_input is not None:
-            pool_id: str = user_input["pool_id"]
-
-            await self.async_set_unique_id(pool_id)
+            username = user_input[CONF_USERNAME]
+            await self.async_set_unique_id(username.lower())
             self._abort_if_unique_id_configured()
 
-            return self.async_create_entry(
-                title=self._available_pools.get(pool_id, pool_id),
-                data={
-                    CONF_USERNAME: self._user_data[CONF_USERNAME],
-                    CONF_PASSWORD: self._user_data[CONF_PASSWORD],
-                    "pool_id": pool_id,
-                },
-            )
+            error = await self._async_validate(username, user_input[CONF_PASSWORD])
+            if error is None:
+                return self.async_create_entry(title=username, data=user_input)
+            errors["base"] = error
 
-        try:
-            session = async_get_clientsession(self.hass)
-            auth = AquariteAuth(
-                session,
-                self._user_data[CONF_USERNAME],
-                self._user_data[CONF_PASSWORD],
-            )
-            await auth.authenticate()
-            api = AquariteClient(auth)
-            self._available_pools = await api.get_pools()
-        except AuthenticationError:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=AUTH_SCHEMA,
-                errors={"base": "auth_error"},
-            )
-        except Exception:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=AUTH_SCHEMA,
-                errors={"base": "unknown_error"},
-            )
-
-        if not self._available_pools:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=AUTH_SCHEMA,
-                errors={"base": "no_pools_found"},
-            )
-
-        pool_schema = vol.Schema(
-            {vol.Required("pool_id"): vol.In(self._available_pools)}
+        return self.async_show_form(
+            step_id="user", data_schema=USER_SCHEMA, errors=errors
         )
-        return self.async_show_form(step_id="pool", data_schema=pool_schema)
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
@@ -147,17 +78,10 @@ class AquariteConfigFlow(ConfigFlow, domain=DOMAIN):
         reauth_entry = self._get_reauth_entry()
 
         if user_input is not None:
-            session = async_get_clientsession(self.hass)
-            try:
-                auth = AquariteAuth(
-                    session,
-                    user_input[CONF_USERNAME],
-                    user_input[CONF_PASSWORD],
-                )
-                await auth.authenticate()
-            except AuthenticationError:
-                errors["base"] = "auth_error"
-            else:
+            error = await self._async_validate(
+                user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+            )
+            if error is None:
                 return self.async_update_reload_and_abort(
                     reauth_entry,
                     data={
@@ -166,6 +90,7 @@ class AquariteConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_PASSWORD: user_input[CONF_PASSWORD],
                     },
                 )
+            errors["base"] = error
 
         schema = vol.Schema(
             {
@@ -188,17 +113,10 @@ class AquariteConfigFlow(ConfigFlow, domain=DOMAIN):
         reconfigure_entry = self._get_reconfigure_entry()
 
         if user_input is not None:
-            session = async_get_clientsession(self.hass)
-            try:
-                auth = AquariteAuth(
-                    session,
-                    user_input[CONF_USERNAME],
-                    user_input[CONF_PASSWORD],
-                )
-                await auth.authenticate()
-            except AuthenticationError:
-                errors["base"] = "auth_error"
-            else:
+            error = await self._async_validate(
+                user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+            )
+            if error is None:
                 return self.async_update_reload_and_abort(
                     reconfigure_entry,
                     data={
@@ -207,6 +125,7 @@ class AquariteConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_PASSWORD: user_input[CONF_PASSWORD],
                     },
                 )
+            errors["base"] = error
 
         schema = vol.Schema(
             {

--- a/custom_components/aquarite/const.py
+++ b/custom_components/aquarite/const.py
@@ -14,8 +14,5 @@ PATH_HASHIDRO = f"{PATH_PREFIX}hasHidro"
 PATH_HASLED = f"{PATH_PREFIX}hasLED"
 
 # Time intervals (seconds)
-DEFAULT_HEALTH_CHECK_INTERVAL = 300  # 5 minutes
+HEALTH_CHECK_INTERVAL = 300  # 5 minutes
 LED_PULSE_DELAY = 1.5  # Delay between off and on when cycling LED color
-
-# Options flow keys
-CONF_HEALTH_CHECK_INTERVAL = "health_check_interval"

--- a/custom_components/aquarite/coordinator.py
+++ b/custom_components/aquarite/coordinator.py
@@ -1,4 +1,5 @@
 """Data coordinator for the Aquarite integration."""
+
 from __future__ import annotations
 
 import asyncio

--- a/custom_components/aquarite/coordinator.py
+++ b/custom_components/aquarite/coordinator.py
@@ -74,6 +74,13 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Get nested data using dot-notation path."""
         return AquariteClient.get_value(self.data, path, default)
 
+    def get_bool(self, path: str) -> bool:
+        """Read a boolean field, coercing string "0" / "1" correctly."""
+        try:
+            return bool(int(self.get_value(path) or 0))
+        except (TypeError, ValueError):
+            return False
+
     async def set_pool_time_to_now(self) -> None:
         """Sync the pool controller clock with the current time."""
         now = dt_util.now()

--- a/custom_components/aquarite/coordinator.py
+++ b/custom_components/aquarite/coordinator.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from typing import Any
 
@@ -13,13 +12,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_HEALTH_CHECK_INTERVAL, DEFAULT_HEALTH_CHECK_INTERVAL
-
 _LOGGER = logging.getLogger(__name__)
 
 
 class AquariteDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Aquarite coordinator using Firestore real-time snapshots."""
+    """Aquarite coordinator for a single pool using Firestore real-time snapshots."""
 
     def __init__(
         self,
@@ -28,92 +25,49 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         auth: AquariteAuth,
         api: AquariteClient,
         pool_id: str,
+        pool_name: str,
     ) -> None:
         """Initialize the coordinator."""
         self.auth = auth
         self.api = api
         self.pool_id: str = pool_id
+        self.pool_name: str = pool_name
         self.watch: Any | None = None
-        self._health_task: asyncio.Task[None] | None = None
-        self._token_task: asyncio.Task[None] | None = None
         self._subscription_lock = asyncio.Lock()
 
         super().__init__(
             hass,
             logger=_LOGGER,
-            name="Aquarite",
+            name=f"Aquarite {pool_name}",
             update_interval=None,
             config_entry=entry,
         )
 
     async def subscribe(self) -> None:
-        """Subscribe to Firestore real-time updates via the library."""
+        """Subscribe to Firestore real-time updates."""
 
         def _on_data(data: dict[str, Any]) -> None:
-            """Callback from Firestore thread; push data to HA loop."""
             self.hass.loop.call_soon_threadsafe(self.async_set_updated_data, data)
 
         self.watch = await self.api.subscribe_pool(self.pool_id, _on_data)
 
-    async def setup_tasks(self) -> None:
-        """Start background health monitoring and token refresh."""
-        self._health_task = self.hass.async_create_background_task(
-            self.periodic_health_check(), "Aquarite health check"
-        )
-        self._token_task = self.hass.async_create_background_task(
-            self._token_refresh_loop(), "Aquarite token refresh"
-        )
-
-    async def _token_refresh_loop(self) -> None:
-        """Maintain token validity with exponential backoff on error."""
-        retry_delay = 10
-        while not self.hass.is_stopping:
-            try:
-                if self.auth.is_token_expiring():
-                    _LOGGER.debug("Token expiring soon, refreshing...")
-                    _, refreshed = await self.auth.get_client()
-                    if refreshed:
-                        await self.refresh_subscription()
-                retry_delay = 10
-                sleep_time = self.auth.calculate_sleep_duration()
-                await asyncio.sleep(sleep_time)
-            except Exception as err:
-                _LOGGER.error(
-                    "Error maintaining token: %s. Retrying in %ss", err, retry_delay
-                )
-                await asyncio.sleep(retry_delay)
-                retry_delay = min(retry_delay * 2, 600)
-
-    async def periodic_health_check(self) -> None:
-        """Monitor connection and resubscribe if needed."""
-        while not self.hass.is_stopping:
-            interval = self.config_entry.options.get(
-                CONF_HEALTH_CHECK_INTERVAL, DEFAULT_HEALTH_CHECK_INTERVAL
-            )
-            await asyncio.sleep(interval)
-            try:
-                await self.auth.get_client()
-            except Exception as err:
-                _LOGGER.error("Health check failed, resubscribing: %s", err)
-                await self.refresh_subscription()
-
     async def refresh_subscription(self) -> None:
-        """Resubscribe to Firestore after a token refresh."""
+        """Tear down and re-establish the Firestore subscription."""
         async with self._subscription_lock:
             _LOGGER.debug("Refreshing Firestore subscription for %s", self.pool_id)
-            if self.watch:
-                await asyncio.to_thread(self.watch.unsubscribe)
+            watch = self.watch
+            self.watch = None
+            if watch is not None:
+                await asyncio.to_thread(watch.unsubscribe)
             await self.subscribe()
 
     async def async_shutdown(self) -> None:
-        """Cleanly unsubscribe and cancel tasks."""
-        if self.watch:
-            await asyncio.to_thread(self.watch.unsubscribe)
-        for task in (self._health_task, self._token_task):
-            if task:
-                task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
+        """Cleanly unsubscribe."""
+        async with self._subscription_lock:
+            watch = self.watch
+            self.watch = None
+            if watch is not None:
+                await asyncio.to_thread(watch.unsubscribe)
         await super().async_shutdown()
 
     def get_value(self, path: str, default: Any = None) -> Any:
@@ -126,5 +80,10 @@ class AquariteDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         offset = now.utcoffset()
         utc_offset = int(offset.total_seconds()) if offset else 0
         timestamp = int(now.timestamp()) + utc_offset
-        _LOGGER.info("Syncing pool localTime to: %s (%s, UTC offset %+ds)", timestamp, now.isoformat(), utc_offset)
+        _LOGGER.info(
+            "Syncing pool localTime to %s (%s, UTC offset %+ds)",
+            timestamp,
+            now.isoformat(),
+            utc_offset,
+        )
         await self.api.set_value(self.pool_id, "main.localTime", timestamp)

--- a/custom_components/aquarite/device_tracker.py
+++ b/custom_components/aquarite/device_tracker.py
@@ -5,7 +5,7 @@ from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AquariteConfigEntry
 from .coordinator import AquariteDataUpdateCoordinator
@@ -17,7 +17,7 @@ PARALLEL_UPDATES = 0
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the pool location tracker."""
     async_add_entities(

--- a/custom_components/aquarite/device_tracker.py
+++ b/custom_components/aquarite/device_tracker.py
@@ -21,9 +21,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the pool location tracker."""
     async_add_entities(
-        PoolLocationDeviceTracker(
-            coordinator, coordinator.pool_id, coordinator.pool_name
-        )
+        PoolLocationDeviceTracker(coordinator)
         for coordinator in entry.runtime_data.coordinators.values()
     )
 
@@ -35,14 +33,9 @@ class PoolLocationDeviceTracker(AquariteEntity, TrackerEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_translation_key = "location"
 
-    def __init__(
-        self,
-        coordinator: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
-    ) -> None:
+    def __init__(self, coordinator: AquariteDataUpdateCoordinator) -> None:
         """Initialize the tracker."""
-        super().__init__(coordinator, pool_id, pool_name)
+        super().__init__(coordinator)
         self._attr_unique_id = self.build_unique_id("location-tracker")
 
     @property

--- a/custom_components/aquarite/device_tracker.py
+++ b/custom_components/aquarite/device_tracker.py
@@ -36,7 +36,7 @@ class PoolLocationDeviceTracker(AquariteEntity, TrackerEntity):
     def __init__(self, coordinator: AquariteDataUpdateCoordinator) -> None:
         """Initialize the tracker."""
         super().__init__(coordinator)
-        self._attr_unique_id = self.build_unique_id("location-tracker")
+        self._attr_unique_id = self.build_unique_id("location")
 
     @property
     def latitude(self) -> float | None:

--- a/custom_components/aquarite/device_tracker.py
+++ b/custom_components/aquarite/device_tracker.py
@@ -1,4 +1,5 @@
 """Aquarite Device Tracker entity."""
+
 from __future__ import annotations
 
 from homeassistant.components.device_tracker import SourceType

--- a/custom_components/aquarite/device_tracker.py
+++ b/custom_components/aquarite/device_tracker.py
@@ -20,13 +20,12 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the pool location tracker."""
-    coordinator = entry.runtime_data.coordinator
-    pool_id = coordinator.pool_id
-    pool_name = entry.title
-
-    async_add_entities([
-        PoolLocationDeviceTracker(coordinator, pool_id, pool_name)
-    ])
+    async_add_entities(
+        PoolLocationDeviceTracker(
+            coordinator, coordinator.pool_id, coordinator.pool_name
+        )
+        for coordinator in entry.runtime_data.coordinators.values()
+    )
 
 
 class PoolLocationDeviceTracker(AquariteEntity, TrackerEntity):

--- a/custom_components/aquarite/diagnostics.py
+++ b/custom_components/aquarite/diagnostics.py
@@ -17,14 +17,18 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: AquariteConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator = entry.runtime_data.coordinator
-
     return {
         "entry": {
             "title": entry.title,
             "data": async_redact_data(dict(entry.data), TO_REDACT_CONFIG),
         },
-        "coordinator_data": async_redact_data(
-            coordinator.data or {}, TO_REDACT_COORDINATOR
-        ),
+        "pools": {
+            pool_id: {
+                "name": coordinator.pool_name,
+                "data": async_redact_data(
+                    coordinator.data or {}, TO_REDACT_COORDINATOR
+                ),
+            }
+            for pool_id, coordinator in entry.runtime_data.coordinators.items()
+        },
     }

--- a/custom_components/aquarite/diagnostics.py
+++ b/custom_components/aquarite/diagnostics.py
@@ -1,4 +1,5 @@
 """Diagnostics support for Aquarite."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/custom_components/aquarite/entity.py
+++ b/custom_components/aquarite/entity.py
@@ -1,4 +1,5 @@
 """Shared base entity helpers for Aquarite."""
+
 from __future__ import annotations
 
 from homeassistant.helpers.device_registry import DeviceInfo

--- a/custom_components/aquarite/entity.py
+++ b/custom_components/aquarite/entity.py
@@ -13,35 +13,18 @@ class AquariteEntity(CoordinatorEntity[AquariteDataUpdateCoordinator]):
 
     _attr_has_entity_name = True
 
-    def __init__(
-        self,
-        coordinator: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
-    ) -> None:
+    def __init__(self, coordinator: AquariteDataUpdateCoordinator) -> None:
         """Initialize the base entity."""
         super().__init__(coordinator)
-        self._pool_id = pool_id
-        self._pool_name = pool_name
         sw_version = coordinator.get_value("main.version")
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, pool_id)},
-            name=pool_name,
+            identifiers={(DOMAIN, coordinator.pool_id)},
+            name=coordinator.pool_name,
             manufacturer=BRAND,
             model=MODEL,
-            sw_version=str(sw_version) if sw_version else None,
+            sw_version=str(sw_version) if sw_version is not None else None,
         )
-
-    @property
-    def pool_id(self) -> str:
-        """Return the pool ID for the entity."""
-        return self._pool_id
-
-    @property
-    def pool_name(self) -> str:
-        """Return the friendly pool name for the entity."""
-        return self._pool_name
 
     def build_unique_id(self, suffix: str) -> str:
         """Return a consistent unique ID for the entity."""
-        return f"{self._pool_id}-{suffix}"
+        return f"{self.coordinator.pool_id}-{suffix}"

--- a/custom_components/aquarite/icons.json
+++ b/custom_components/aquarite/icons.json
@@ -28,29 +28,8 @@
       "filtration_intel_time": {
         "default": "mdi:timer-outline"
       },
-      "pool_name": {
-        "default": "mdi:pool"
-      },
       "rssi": {
         "default": "mdi:wifi"
-      },
-      "city": {
-        "default": "mdi:city"
-      },
-      "street": {
-        "default": "mdi:road"
-      },
-      "zipcode": {
-        "default": "mdi:numeric"
-      },
-      "country": {
-        "default": "mdi:earth"
-      },
-      "latitude": {
-        "default": "mdi:latitude"
-      },
-      "longitude": {
-        "default": "mdi:longitude"
       }
     },
     "binary_sensor": {

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -6,9 +6,11 @@ from typing import Any
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AquariteConfigEntry
+from .const import DOMAIN
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
@@ -79,11 +81,15 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
             await self.coordinator.api.set_value(
                 self.coordinator.pool_id, self._value_path, 1 if state else 0
             )
-        except Exception:
+        except Exception as err:
             # If the API call fails immediately, reset and revert UI
             self._target_state = None
             self.async_write_ha_state()
-            raise
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -50,7 +50,7 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
     @property
     def is_on(self) -> bool:
         """Return true if light is on."""
-        actual_state = bool(self.coordinator.get_value(self._value_path))
+        actual_state = self.coordinator.get_bool(self._value_path)
 
         # If we aren't waiting for a change, show actual state
         if self._target_state is None:

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -25,8 +25,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Aquarite light platform."""
     async_add_entities(
-        AquariteLightEntity(dataservice, "Light", "pool_light", "light.status")
-        for dataservice in entry.runtime_data.coordinators.values()
+        AquariteLightEntity(coordinator)
+        for coordinator in entry.runtime_data.coordinators.values()
     )
 
 
@@ -35,19 +35,13 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
 
     _attr_supported_color_modes = {ColorMode.ONOFF}
     _attr_color_mode = ColorMode.ONOFF
+    _attr_translation_key = "pool_light"
+    _value_path = "light.status"
 
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        name: str,
-        translation_key: str,
-        value_path: str,
-    ) -> None:
+    def __init__(self, coordinator: AquariteDataUpdateCoordinator) -> None:
         """Initialize the light entity."""
-        super().__init__(dataservice)
-        self._value_path = value_path
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
+        super().__init__(coordinator)
+        self._attr_unique_id = self.build_unique_id("pool_light")
 
         # Reconciliation logic
         self._target_state: bool | None = None

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -24,12 +24,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Aquarite light platform."""
-    dataservice = entry.runtime_data.coordinator
-    pool_id, pool_name = dataservice.pool_id, entry.title
-
-    async_add_entities([
-        AquariteLightEntity(dataservice, pool_id, pool_name, "Light", "pool_light", "light.status")
-    ])
+    async_add_entities(
+        AquariteLightEntity(
+            dataservice, dataservice.pool_id, dataservice.pool_name,
+            "Light", "pool_light", "light.status",
+        )
+        for dataservice in entry.runtime_data.coordinators.values()
+    )
 
 
 class AquariteLightEntity(AquariteEntity, LightEntity):

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -25,10 +25,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Aquarite light platform."""
     async_add_entities(
-        AquariteLightEntity(
-            dataservice, dataservice.pool_id, dataservice.pool_name,
-            "Light", "pool_light", "light.status",
-        )
+        AquariteLightEntity(dataservice, "Light", "pool_light", "light.status")
         for dataservice in entry.runtime_data.coordinators.values()
     )
 
@@ -42,14 +39,12 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
     def __init__(
         self,
         dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
         name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
         """Initialize the light entity."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._value_path = value_path
         self._attr_translation_key = translation_key
         self._attr_unique_id = self.build_unique_id(name)
@@ -88,7 +83,7 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
 
         try:
             await self.coordinator.api.set_value(
-                self._pool_id, self._value_path, 1 if state else 0
+                self.coordinator.pool_id, self._value_path, 1 if state else 0
             )
         except Exception:
             # If the API call fails immediately, reset and revert UI

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import time
 from typing import Any
 
+from aioaquarite import AquariteError
+
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -81,7 +83,7 @@ class AquariteLightEntity(AquariteEntity, LightEntity):
             await self.coordinator.api.set_value(
                 self.coordinator.pool_id, self._value_path, 1 if state else 0
             )
-        except Exception as err:
+        except AquariteError as err:
             # If the API call fails immediately, reset and revert UI
             self._target_state = None
             self.async_write_ha_state()

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -7,7 +7,7 @@ from typing import Any
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AquariteConfigEntry
 from .const import DOMAIN
@@ -23,7 +23,7 @@ PARALLEL_UPDATES = 1
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Aquarite light platform."""
     async_add_entities(

--- a/custom_components/aquarite/light.py
+++ b/custom_components/aquarite/light.py
@@ -1,4 +1,5 @@
 """Aquarite Light entity with State Reconciliation and Failure Handling."""
+
 from __future__ import annotations
 
 import time

--- a/custom_components/aquarite/manifest.json
+++ b/custom_components/aquarite/manifest.json
@@ -1,26 +1,25 @@
 {
-    "domain": "aquarite",
-    "name": "Aquarite",
-    "codeowners": ["@fdebrus"],
-    "config_flow": true,
-    "documentation": "https://community.home-assistant.io/t/custom-component-hayward-aquarite/728136",
-    "homeassistant": "2024.1.0",
-    "iot_class": "cloud_push",
-    "issue_tracker": "https://github.com/fdebrus/hayward-ha/issues",
-    "loggers": ["custom_components.aquarite", "aioaquarite"],
-    "requirements": [
-        "aioaquarite==0.2.0"
-    ],
-    "supported_platforms": [
-        "binary_sensor",
-        "button",
-        "device_tracker",
-        "light",
-        "number",
-        "select",
-        "sensor",
-        "switch",
-        "time"
-    ],
-    "version": "1.2.0"
+  "domain": "aquarite",
+  "name": "Aquarite",
+  "codeowners": ["@fdebrus"],
+  "config_flow": true,
+  "documentation": "https://community.home-assistant.io/t/custom-component-hayward-aquarite/728136",
+  "homeassistant": "2024.1.0",
+  "integration_type": "hub",
+  "iot_class": "cloud_push",
+  "issue_tracker": "https://github.com/fdebrus/hayward-ha/issues",
+  "loggers": ["custom_components.aquarite", "aioaquarite"],
+  "requirements": ["aioaquarite==0.2.0"],
+  "supported_platforms": [
+    "binary_sensor",
+    "button",
+    "device_tracker",
+    "light",
+    "number",
+    "select",
+    "sensor",
+    "switch",
+    "time"
+  ],
+  "version": "2.0.0"
 }

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AquariteConfigEntry
+from .const import DOMAIN
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
@@ -184,4 +185,8 @@ class AquariteNumber(AquariteEntity, NumberEntity):
                 raw,
             )
         except Exception as err:
-            raise HomeAssistantError(f"Failed to set value: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -1,9 +1,14 @@
 """Aquarite Number entities."""
 from __future__ import annotations
 
-from typing import Final
+from collections.abc import Callable
+from dataclasses import dataclass
 
-from homeassistant.components.number import NumberDeviceClass, NumberEntity
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+)
 from homeassistant.const import EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -16,152 +21,167 @@ from .entity import AquariteEntity
 PARALLEL_UPDATES = 1
 
 
+@dataclass(frozen=True, kw_only=True)
+class AquariteNumberEntityDescription(NumberEntityDescription):
+    """Describes an Aquarite number entity."""
+
+    value_path: str
+    scale: int = 1
+    max_fn: Callable[[AquariteDataUpdateCoordinator], float] | None = None
+    exists_fn: Callable[[AquariteDataUpdateCoordinator], bool] | None = None
+
+
+def _max_electrolysis(coordinator: AquariteDataUpdateCoordinator) -> float:
+    raw = coordinator.get_value("hidro.maxAllowedValue", 0)
+    try:
+        return int(raw) / 10 if raw else 50.0
+    except (TypeError, ValueError):
+        return 50.0
+
+
+NUMBERS: tuple[AquariteNumberEntityDescription, ...] = (
+    AquariteNumberEntityDescription(
+        key="redox_setpoint",
+        translation_key="redox_setpoint",
+        native_min_value=500,
+        native_max_value=800,
+        native_unit_of_measurement="mV",
+        value_path="modules.rx.status.value",
+    ),
+    AquariteNumberEntityDescription(
+        key="ph_low",
+        translation_key="ph_low",
+        native_min_value=6,
+        native_max_value=8,
+        native_unit_of_measurement="pH",
+        value_path="modules.ph.status.low_value",
+        scale=100,
+    ),
+    AquariteNumberEntityDescription(
+        key="ph_max",
+        translation_key="ph_max",
+        native_min_value=6,
+        native_max_value=8,
+        native_unit_of_measurement="pH",
+        value_path="modules.ph.status.high_value",
+        scale=100,
+    ),
+    AquariteNumberEntityDescription(
+        key="electrolysis_setpoint",
+        translation_key="electrolysis_setpoint",
+        native_min_value=0,
+        native_max_value=50,  # overridden by max_fn at runtime
+        native_unit_of_measurement="gr/h",
+        value_path="hidro.level",
+        scale=10,
+        max_fn=_max_electrolysis,
+    ),
+    AquariteNumberEntityDescription(
+        key="intel_mode_temperature",
+        translation_key="intel_mode_temperature",
+        native_min_value=5,
+        native_max_value=40,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        value_path="filtration.intel.temp",
+    ),
+    AquariteNumberEntityDescription(
+        key="heating_mode_min_temperature",
+        translation_key="heating_mode_min_temperature",
+        native_min_value=5,
+        native_max_value=40,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        value_path="filtration.heating.temp",
+        exists_fn=lambda c: bool(c.get_value("filtration.hasHeat")),
+    ),
+    AquariteNumberEntityDescription(
+        key="heating_mode_max_temperature",
+        translation_key="heating_mode_max_temperature",
+        native_min_value=5,
+        native_max_value=40,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        value_path="filtration.heating.tempHi",
+        exists_fn=lambda c: bool(c.get_value("filtration.hasHeat")),
+    ),
+    AquariteNumberEntityDescription(
+        key="smart_mode_min_temperature",
+        translation_key="smart_mode_min_temperature",
+        native_min_value=5,
+        native_max_value=40,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        value_path="filtration.smart.tempMin",
+        exists_fn=lambda c: bool(c.get_value("filtration.hasSmart")),
+    ),
+    AquariteNumberEntityDescription(
+        key="smart_mode_max_temperature",
+        translation_key="smart_mode_max_temperature",
+        native_min_value=5,
+        native_max_value=40,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        value_path="filtration.smart.tempHigh",
+        exists_fn=lambda c: bool(c.get_value("filtration.hasSmart")),
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Aquarite number entities."""
-    entities: list[AquariteNumberEntity] = []
-
-    for dataservice in entry.runtime_data.coordinators.values():
-        # Safely determine max electrolysis
-        raw_max = dataservice.get_value("hidro.maxAllowedValue", 0)
-        try:
-            max_electrolysis = int(raw_max) / 10 if raw_max else 50.0
-        except (ValueError, TypeError):
-            max_electrolysis = 50.0
-
-        entities.extend([
-            AquariteNumberEntity(
-                dataservice,
-                500, 800, "Redox Setpoint", "redox_setpoint", "modules.rx.status.value",
-            ),
-            AquariteNumberEntity(
-                dataservice,
-                6, 8, "pH Low", "ph_low", "modules.ph.status.low_value",
-            ),
-            AquariteNumberEntity(
-                dataservice,
-                6, 8, "pH Max", "ph_max", "modules.ph.status.high_value",
-            ),
-            AquariteNumberEntity(
-                dataservice,
-                0, max_electrolysis, "Electrolysis Setpoint", "electrolysis_setpoint", "hidro.level",
-            ),
-            # INTEL mode target temperature (matches the "Température" field shown
-            # under the INTEL slider position in the Hayward app).
-            AquariteNumberEntity(
-                dataservice,
-                5, 40, "Intel Mode Temperature", "intel_mode_temperature", "filtration.intel.temp",
-            ),
-        ])
-
-        # HEAT mode min/max range (the two arrows under "Température minimale" /
-        # "Température maximale" when the HEAT slider position is selected).
-        # Translation keys are intentionally renamed from PR #62 to clarify they
-        # are bounds, not single setpoints. The Python `name` arguments are kept
-        # unchanged so existing unique_ids are preserved.
-        if dataservice.get_value("filtration.hasHeat"):
-            entities.extend([
-                AquariteNumberEntity(
-                    dataservice,
-                    5, 40, "Heating Setpoint", "heating_mode_min_temperature", "filtration.heating.temp",
-                ),
-                AquariteNumberEntity(
-                    dataservice,
-                    5, 40, "Heating High Setpoint", "heating_mode_max_temperature", "filtration.heating.tempHi",
-                ),
-            ])
-
-        # SMART mode min/max range (replaces the read-only sensors that previously
-        # exposed `filtration.smart.tempMin` / `tempHigh` — see PR description for
-        # the breaking-change note).
-        if dataservice.get_value("filtration.hasSmart"):
-            entities.extend([
-                AquariteNumberEntity(
-                    dataservice,
-                    5, 40, "Smart Mode Min Temperature", "smart_mode_min_temperature", "filtration.smart.tempMin",
-                ),
-                AquariteNumberEntity(
-                    dataservice,
-                    5, 40, "Smart Mode Max Temperature", "smart_mode_max_temperature", "filtration.smart.tempHigh",
-                ),
-            ])
-
-    async_add_entities(entities)
+    async_add_entities(
+        AquariteNumber(coordinator, description)
+        for coordinator in entry.runtime_data.coordinators.values()
+        for description in NUMBERS
+        if description.exists_fn is None or description.exists_fn(coordinator)
+    )
 
 
-class AquariteNumberEntity(AquariteEntity, NumberEntity):
-    """Number entity for Aquarite data points."""
+class AquariteNumber(AquariteEntity, NumberEntity):
+    """Aquarite number entity."""
 
     _attr_entity_category = EntityCategory.CONFIG
-
-    SCALE_MAP: Final[dict[str, int]] = {
-        "modules.ph.status.low_value": 100,
-        "modules.ph.status.high_value": 100,
-        "hidro.level": 10,
-    }
-    UNIT_MAP: Final[dict[str, str]] = {
-        "modules.rx.status.value": "mV",
-        "modules.ph.status.low_value": "pH",
-        "modules.ph.status.high_value": "pH",
-        "hidro.level": "gr/h",
-        "filtration.heating.temp": UnitOfTemperature.CELSIUS,
-        "filtration.heating.tempHi": UnitOfTemperature.CELSIUS,
-        "filtration.intel.temp": UnitOfTemperature.CELSIUS,
-        "filtration.smart.tempMin": UnitOfTemperature.CELSIUS,
-        "filtration.smart.tempHigh": UnitOfTemperature.CELSIUS,
-    }
-    DEVICE_CLASS_MAP: Final[dict[str, NumberDeviceClass]] = {
-        "filtration.heating.temp": NumberDeviceClass.TEMPERATURE,
-        "filtration.heating.tempHi": NumberDeviceClass.TEMPERATURE,
-        "filtration.intel.temp": NumberDeviceClass.TEMPERATURE,
-        "filtration.smart.tempMin": NumberDeviceClass.TEMPERATURE,
-        "filtration.smart.tempHigh": NumberDeviceClass.TEMPERATURE,
-    }
+    entity_description: AquariteNumberEntityDescription
 
     def __init__(
         self,
-        dataservice: AquariteDataUpdateCoordinator,
-        value_min: float,
-        value_max: float,
-        name: str,
-        translation_key: str,
-        value_path: str,
+        coordinator: AquariteDataUpdateCoordinator,
+        description: AquariteNumberEntityDescription,
     ) -> None:
         """Initialize the number entity."""
-        super().__init__(dataservice)
-        self._attr_native_min_value = value_min
-        self._attr_native_max_value = value_max
-        self._value_path = value_path
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
-        self._attr_native_unit_of_measurement = self.UNIT_MAP.get(value_path)
-        self._attr_device_class = self.DEVICE_CLASS_MAP.get(value_path)
-        self._attr_native_step = self._get_scaled_step()
-
-    def _get_scaled_step(self) -> float:
-        """Return step size based on scale factor."""
-        scale = self.SCALE_MAP.get(self._value_path)
-        return 1 / scale if scale else 1.0
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = self.build_unique_id(description.key)
+        self._attr_native_step = 1 / description.scale if description.scale != 1 else 1.0
+        if description.max_fn is not None:
+            self._attr_native_max_value = description.max_fn(coordinator)
 
     @property
     def native_value(self) -> float | None:
         """Return the current value."""
-        raw_value = self.coordinator.get_value(self._value_path)
-        if raw_value is None:
+        raw = self.coordinator.get_value(self.entity_description.value_path)
+        if raw is None:
             return None
-        scale = self.SCALE_MAP.get(self._value_path)
-        return int(raw_value) / scale if scale else float(raw_value)
+        scale = self.entity_description.scale
+        try:
+            return int(raw) / scale if scale != 1 else float(raw)
+        except (TypeError, ValueError):
+            return None
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
-        scale = self.SCALE_MAP.get(self._value_path)
-        raw_value = int(value * scale) if scale else value
+        scale = self.entity_description.scale
+        raw = int(round(value * scale)) if scale != 1 else value
         try:
             await self.coordinator.api.set_value(
-                self.coordinator.pool_id, self._value_path, raw_value
+                self.coordinator.pool_id,
+                self.entity_description.value_path,
+                raw,
             )
         except Exception as err:
             raise HomeAssistantError(f"Failed to set value: {err}") from err

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -25,8 +25,6 @@ async def async_setup_entry(
     entities: list[AquariteNumberEntity] = []
 
     for dataservice in entry.runtime_data.coordinators.values():
-        pool_id, pool_name = dataservice.pool_id, dataservice.pool_name
-
         # Safely determine max electrolysis
         raw_max = dataservice.get_value("hidro.maxAllowedValue", 0)
         try:
@@ -36,25 +34,25 @@ async def async_setup_entry(
 
         entities.extend([
             AquariteNumberEntity(
-                dataservice, pool_id, pool_name,
+                dataservice,
                 500, 800, "Redox Setpoint", "redox_setpoint", "modules.rx.status.value",
             ),
             AquariteNumberEntity(
-                dataservice, pool_id, pool_name,
+                dataservice,
                 6, 8, "pH Low", "ph_low", "modules.ph.status.low_value",
             ),
             AquariteNumberEntity(
-                dataservice, pool_id, pool_name,
+                dataservice,
                 6, 8, "pH Max", "ph_max", "modules.ph.status.high_value",
             ),
             AquariteNumberEntity(
-                dataservice, pool_id, pool_name,
+                dataservice,
                 0, max_electrolysis, "Electrolysis Setpoint", "electrolysis_setpoint", "hidro.level",
             ),
             # INTEL mode target temperature (matches the "Température" field shown
             # under the INTEL slider position in the Hayward app).
             AquariteNumberEntity(
-                dataservice, pool_id, pool_name,
+                dataservice,
                 5, 40, "Intel Mode Temperature", "intel_mode_temperature", "filtration.intel.temp",
             ),
         ])
@@ -67,11 +65,11 @@ async def async_setup_entry(
         if dataservice.get_value("filtration.hasHeat"):
             entities.extend([
                 AquariteNumberEntity(
-                    dataservice, pool_id, pool_name,
+                    dataservice,
                     5, 40, "Heating Setpoint", "heating_mode_min_temperature", "filtration.heating.temp",
                 ),
                 AquariteNumberEntity(
-                    dataservice, pool_id, pool_name,
+                    dataservice,
                     5, 40, "Heating High Setpoint", "heating_mode_max_temperature", "filtration.heating.tempHi",
                 ),
             ])
@@ -82,11 +80,11 @@ async def async_setup_entry(
         if dataservice.get_value("filtration.hasSmart"):
             entities.extend([
                 AquariteNumberEntity(
-                    dataservice, pool_id, pool_name,
+                    dataservice,
                     5, 40, "Smart Mode Min Temperature", "smart_mode_min_temperature", "filtration.smart.tempMin",
                 ),
                 AquariteNumberEntity(
-                    dataservice, pool_id, pool_name,
+                    dataservice,
                     5, 40, "Smart Mode Max Temperature", "smart_mode_max_temperature", "filtration.smart.tempHigh",
                 ),
             ])
@@ -126,8 +124,6 @@ class AquariteNumberEntity(AquariteEntity, NumberEntity):
     def __init__(
         self,
         dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
         value_min: float,
         value_max: float,
         name: str,
@@ -135,7 +131,7 @@ class AquariteNumberEntity(AquariteEntity, NumberEntity):
         value_path: str,
     ) -> None:
         """Initialize the number entity."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._attr_native_min_value = value_min
         self._attr_native_max_value = value_max
         self._value_path = value_path
@@ -165,7 +161,7 @@ class AquariteNumberEntity(AquariteEntity, NumberEntity):
         raw_value = int(value * scale) if scale else value
         try:
             await self.coordinator.api.set_value(
-                self._pool_id, self._value_path, raw_value
+                self.coordinator.pool_id, self._value_path, raw_value
             )
         except Exception as err:
             raise HomeAssistantError(f"Failed to set value: {err}") from err

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from aioaquarite import AquariteError
+
 from homeassistant.components.number import (
     NumberDeviceClass,
     NumberEntity,
@@ -188,7 +190,7 @@ class AquariteNumber(AquariteEntity, NumberEntity):
                 self.entity_description.value_path,
                 raw,
             )
-        except Exception as err:
+        except AquariteError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -1,4 +1,5 @@
 """Aquarite Number entities."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -164,7 +165,9 @@ class AquariteNumber(AquariteEntity, NumberEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = self.build_unique_id(description.key)
-        self._attr_native_step = 1 / description.scale if description.scale != 1 else 1.0
+        self._attr_native_step = (
+            1 / description.scale if description.scale != 1 else 1.0
+        )
         if description.max_fn is not None:
             self._attr_native_max_value = description.max_fn(coordinator)
 

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -93,7 +93,7 @@ NUMBERS: tuple[AquariteNumberEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=NumberDeviceClass.TEMPERATURE,
         value_path="filtration.heating.temp",
-        exists_fn=lambda c: bool(c.get_value("filtration.hasHeat")),
+        exists_fn=lambda c: c.get_bool("filtration.hasHeat"),
     ),
     AquariteNumberEntityDescription(
         key="heating_mode_max_temperature",
@@ -103,7 +103,7 @@ NUMBERS: tuple[AquariteNumberEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=NumberDeviceClass.TEMPERATURE,
         value_path="filtration.heating.tempHi",
-        exists_fn=lambda c: bool(c.get_value("filtration.hasHeat")),
+        exists_fn=lambda c: c.get_bool("filtration.hasHeat"),
     ),
     AquariteNumberEntityDescription(
         key="smart_mode_min_temperature",
@@ -113,7 +113,7 @@ NUMBERS: tuple[AquariteNumberEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=NumberDeviceClass.TEMPERATURE,
         value_path="filtration.smart.tempMin",
-        exists_fn=lambda c: bool(c.get_value("filtration.hasSmart")),
+        exists_fn=lambda c: c.get_bool("filtration.hasSmart"),
     ),
     AquariteNumberEntityDescription(
         key="smart_mode_max_temperature",
@@ -123,7 +123,7 @@ NUMBERS: tuple[AquariteNumberEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=NumberDeviceClass.TEMPERATURE,
         value_path="filtration.smart.tempHigh",
-        exists_fn=lambda c: bool(c.get_value("filtration.hasSmart")),
+        exists_fn=lambda c: c.get_bool("filtration.hasSmart"),
     ),
 )
 

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -9,10 +9,14 @@ from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
 )
-from homeassistant.const import EntityCategory, UnitOfTemperature
+from homeassistant.const import (
+    EntityCategory,
+    UnitOfElectricPotential,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AquariteConfigEntry
 from .const import DOMAIN
@@ -46,7 +50,7 @@ NUMBERS: tuple[AquariteNumberEntityDescription, ...] = (
         translation_key="redox_setpoint",
         native_min_value=500,
         native_max_value=800,
-        native_unit_of_measurement="mV",
+        native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
         value_path="modules.rx.status.value",
     ),
     AquariteNumberEntityDescription(
@@ -72,7 +76,7 @@ NUMBERS: tuple[AquariteNumberEntityDescription, ...] = (
         translation_key="electrolysis_setpoint",
         native_min_value=0,
         native_max_value=50,  # overridden by max_fn at runtime
-        native_unit_of_measurement="gr/h",
+        native_unit_of_measurement="g/h",
         value_path="hidro.level",
         scale=10,
         max_fn=_max_electrolysis,
@@ -132,7 +136,7 @@ NUMBERS: tuple[AquariteNumberEntityDescription, ...] = (
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Aquarite number entities."""
     async_add_entities(

--- a/custom_components/aquarite/number.py
+++ b/custom_components/aquarite/number.py
@@ -22,72 +22,74 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Aquarite number entities."""
-    dataservice = entry.runtime_data.coordinator
-    pool_id, pool_name = dataservice.pool_id, entry.title
+    entities: list[AquariteNumberEntity] = []
 
-    # Safely determine max electrolysis
-    raw_max = dataservice.get_value("hidro.maxAllowedValue", 0)
-    try:
-        max_electrolysis = int(raw_max) / 10 if raw_max else 50.0
-    except (ValueError, TypeError):
-        max_electrolysis = 50.0
+    for dataservice in entry.runtime_data.coordinators.values():
+        pool_id, pool_name = dataservice.pool_id, dataservice.pool_name
 
-    entities = [
-        AquariteNumberEntity(
-            dataservice, pool_id, pool_name,
-            500, 800, "Redox Setpoint", "redox_setpoint", "modules.rx.status.value",
-        ),
-        AquariteNumberEntity(
-            dataservice, pool_id, pool_name,
-            6, 8, "pH Low", "ph_low", "modules.ph.status.low_value",
-        ),
-        AquariteNumberEntity(
-            dataservice, pool_id, pool_name,
-            6, 8, "pH Max", "ph_max", "modules.ph.status.high_value",
-        ),
-        AquariteNumberEntity(
-            dataservice, pool_id, pool_name,
-            0, max_electrolysis, "Electrolysis Setpoint", "electrolysis_setpoint", "hidro.level",
-        ),
-        # INTEL mode target temperature (matches the "Température" field shown
-        # under the INTEL slider position in the Hayward app).
-        AquariteNumberEntity(
-            dataservice, pool_id, pool_name,
-            5, 40, "Intel Mode Temperature", "intel_mode_temperature", "filtration.intel.temp",
-        ),
-    ]
+        # Safely determine max electrolysis
+        raw_max = dataservice.get_value("hidro.maxAllowedValue", 0)
+        try:
+            max_electrolysis = int(raw_max) / 10 if raw_max else 50.0
+        except (ValueError, TypeError):
+            max_electrolysis = 50.0
 
-    # HEAT mode min/max range (the two arrows under "Température minimale" /
-    # "Température maximale" when the HEAT slider position is selected).
-    # Translation keys are intentionally renamed from PR #62 to clarify they
-    # are bounds, not single setpoints. The Python `name` arguments are kept
-    # unchanged so existing unique_ids are preserved.
-    if dataservice.get_value("filtration.hasHeat"):
         entities.extend([
             AquariteNumberEntity(
                 dataservice, pool_id, pool_name,
-                5, 40, "Heating Setpoint", "heating_mode_min_temperature", "filtration.heating.temp",
+                500, 800, "Redox Setpoint", "redox_setpoint", "modules.rx.status.value",
             ),
             AquariteNumberEntity(
                 dataservice, pool_id, pool_name,
-                5, 40, "Heating High Setpoint", "heating_mode_max_temperature", "filtration.heating.tempHi",
+                6, 8, "pH Low", "ph_low", "modules.ph.status.low_value",
+            ),
+            AquariteNumberEntity(
+                dataservice, pool_id, pool_name,
+                6, 8, "pH Max", "ph_max", "modules.ph.status.high_value",
+            ),
+            AquariteNumberEntity(
+                dataservice, pool_id, pool_name,
+                0, max_electrolysis, "Electrolysis Setpoint", "electrolysis_setpoint", "hidro.level",
+            ),
+            # INTEL mode target temperature (matches the "Température" field shown
+            # under the INTEL slider position in the Hayward app).
+            AquariteNumberEntity(
+                dataservice, pool_id, pool_name,
+                5, 40, "Intel Mode Temperature", "intel_mode_temperature", "filtration.intel.temp",
             ),
         ])
 
-    # SMART mode min/max range (replaces the read-only sensors that previously
-    # exposed `filtration.smart.tempMin` / `tempHigh` — see PR description for
-    # the breaking-change note).
-    if dataservice.get_value("filtration.hasSmart"):
-        entities.extend([
-            AquariteNumberEntity(
-                dataservice, pool_id, pool_name,
-                5, 40, "Smart Mode Min Temperature", "smart_mode_min_temperature", "filtration.smart.tempMin",
-            ),
-            AquariteNumberEntity(
-                dataservice, pool_id, pool_name,
-                5, 40, "Smart Mode Max Temperature", "smart_mode_max_temperature", "filtration.smart.tempHigh",
-            ),
-        ])
+        # HEAT mode min/max range (the two arrows under "Température minimale" /
+        # "Température maximale" when the HEAT slider position is selected).
+        # Translation keys are intentionally renamed from PR #62 to clarify they
+        # are bounds, not single setpoints. The Python `name` arguments are kept
+        # unchanged so existing unique_ids are preserved.
+        if dataservice.get_value("filtration.hasHeat"):
+            entities.extend([
+                AquariteNumberEntity(
+                    dataservice, pool_id, pool_name,
+                    5, 40, "Heating Setpoint", "heating_mode_min_temperature", "filtration.heating.temp",
+                ),
+                AquariteNumberEntity(
+                    dataservice, pool_id, pool_name,
+                    5, 40, "Heating High Setpoint", "heating_mode_max_temperature", "filtration.heating.tempHi",
+                ),
+            ])
+
+        # SMART mode min/max range (replaces the read-only sensors that previously
+        # exposed `filtration.smart.tempMin` / `tempHigh` — see PR description for
+        # the breaking-change note).
+        if dataservice.get_value("filtration.hasSmart"):
+            entities.extend([
+                AquariteNumberEntity(
+                    dataservice, pool_id, pool_name,
+                    5, 40, "Smart Mode Min Temperature", "smart_mode_min_temperature", "filtration.smart.tempMin",
+                ),
+                AquariteNumberEntity(
+                    dataservice, pool_id, pool_name,
+                    5, 40, "Smart Mode Max Temperature", "smart_mode_max_temperature", "filtration.smart.tempHigh",
+                ),
+            ])
 
     async_add_entities(entities)
 

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from aioaquarite import AquariteError
+
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -100,7 +102,7 @@ class AquariteSelect(AquariteEntity, SelectEntity):
                 self.entity_description.value_path,
                 self.entity_description.options_map.index(option),
             )
-        except Exception as err:
+        except AquariteError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -23,30 +23,32 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up select entities."""
-    dataservice = entry.runtime_data.coordinator
-    pool_id, pool_name = dataservice.pool_id, entry.title
+    entities: list[AquariteSelectEntity] = []
 
-    entities = [
-        AquariteSelectEntity(
-            dataservice, pool_id, pool_name,
-            "Pump Mode", "pump_mode", "filtration.mode", PUMP_MODE_OPTIONS,
-        ),
-        AquariteSelectEntity(
-            dataservice, pool_id, pool_name,
-            "Pump Speed", "pump_speed", "filtration.manVel", PUMP_SPEED_OPTIONS,
-        ),
-    ]
+    for dataservice in entry.runtime_data.coordinators.values():
+        pool_id, pool_name = dataservice.pool_id, dataservice.pool_name
 
-    for index in range(1, 4):
-        entities.append(
+        entities.extend([
             AquariteSelectEntity(
                 dataservice, pool_id, pool_name,
-                f"Filtration Timer Speed {index}",
-                f"filtration_timer_speed_{index}",
-                f"filtration.timerVel{index}",
-                TIMER_SPEED_OPTIONS,
+                "Pump Mode", "pump_mode", "filtration.mode", PUMP_MODE_OPTIONS,
+            ),
+            AquariteSelectEntity(
+                dataservice, pool_id, pool_name,
+                "Pump Speed", "pump_speed", "filtration.manVel", PUMP_SPEED_OPTIONS,
+            ),
+        ])
+
+        for index in range(1, 4):
+            entities.append(
+                AquariteSelectEntity(
+                    dataservice, pool_id, pool_name,
+                    f"Filtration Timer Speed {index}",
+                    f"filtration_timer_speed_{index}",
+                    f"filtration.timerVel{index}",
+                    TIMER_SPEED_OPTIONS,
+                )
             )
-        )
 
     async_add_entities(entities)
 

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -9,6 +9,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AquariteConfigEntry
+from .const import DOMAIN
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
@@ -100,4 +101,8 @@ class AquariteSelect(AquariteEntity, SelectEntity):
                 self.entity_description.options_map.index(option),
             )
         except Exception as err:
-            raise HomeAssistantError(f"Failed to select option: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -26,15 +26,13 @@ async def async_setup_entry(
     entities: list[AquariteSelectEntity] = []
 
     for dataservice in entry.runtime_data.coordinators.values():
-        pool_id, pool_name = dataservice.pool_id, dataservice.pool_name
-
         entities.extend([
             AquariteSelectEntity(
-                dataservice, pool_id, pool_name,
+                dataservice,
                 "Pump Mode", "pump_mode", "filtration.mode", PUMP_MODE_OPTIONS,
             ),
             AquariteSelectEntity(
-                dataservice, pool_id, pool_name,
+                dataservice,
                 "Pump Speed", "pump_speed", "filtration.manVel", PUMP_SPEED_OPTIONS,
             ),
         ])
@@ -42,7 +40,7 @@ async def async_setup_entry(
         for index in range(1, 4):
             entities.append(
                 AquariteSelectEntity(
-                    dataservice, pool_id, pool_name,
+                    dataservice,
                     f"Filtration Timer Speed {index}",
                     f"filtration_timer_speed_{index}",
                     f"filtration.timerVel{index}",
@@ -59,15 +57,13 @@ class AquariteSelectEntity(AquariteEntity, SelectEntity):
     def __init__(
         self,
         dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
         name: str,
         translation_key: str,
         value_path: str,
         options: tuple[str, ...],
     ) -> None:
         """Initialize the select entity."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._value_path = value_path
         self._options_map = options
         self._attr_translation_key = translation_key
@@ -87,7 +83,9 @@ class AquariteSelectEntity(AquariteEntity, SelectEntity):
         """Select an option."""
         try:
             await self.coordinator.api.set_value(
-                self._pool_id, self._value_path, self._options_map.index(option)
+                self.coordinator.pool_id,
+                self._value_path,
+                self._options_map.index(option),
             )
         except Exception as err:
             raise HomeAssistantError(f"Failed to select option: {err}") from err

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -1,7 +1,9 @@
 """Aquarite Select entities."""
 from __future__ import annotations
 
-from homeassistant.components.select import SelectEntity
+from dataclasses import dataclass
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -10,11 +12,46 @@ from . import AquariteConfigEntry
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
-PUMP_MODE_OPTIONS: tuple[str, ...] = ("manual", "auto", "heat", "smart", "intel")
-PUMP_SPEED_OPTIONS: tuple[str, ...] = ("slow", "medium", "high")
-TIMER_SPEED_OPTIONS: tuple[str, ...] = ("slow", "medium", "high")
-
 PARALLEL_UPDATES = 1
+
+PUMP_MODE_OPTIONS: tuple[str, ...] = ("manual", "auto", "heat", "smart", "intel")
+SPEED_OPTIONS: tuple[str, ...] = ("slow", "medium", "high")
+
+
+@dataclass(frozen=True, kw_only=True)
+class AquariteSelectEntityDescription(SelectEntityDescription):
+    """Describes an Aquarite select entity."""
+
+    value_path: str
+    options_map: tuple[str, ...]
+
+
+SELECTS: tuple[AquariteSelectEntityDescription, ...] = (
+    AquariteSelectEntityDescription(
+        key="pump_mode",
+        translation_key="pump_mode",
+        options=list(PUMP_MODE_OPTIONS),
+        options_map=PUMP_MODE_OPTIONS,
+        value_path="filtration.mode",
+    ),
+    AquariteSelectEntityDescription(
+        key="pump_speed",
+        translation_key="pump_speed",
+        options=list(SPEED_OPTIONS),
+        options_map=SPEED_OPTIONS,
+        value_path="filtration.manVel",
+    ),
+    *(
+        AquariteSelectEntityDescription(
+            key=f"filtration_timer_speed_{i}",
+            translation_key=f"filtration_timer_speed_{i}",
+            options=list(SPEED_OPTIONS),
+            options_map=SPEED_OPTIONS,
+            value_path=f"filtration.timerVel{i}",
+        )
+        for i in range(1, 4)
+    ),
+)
 
 
 async def async_setup_entry(
@@ -23,59 +60,34 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up select entities."""
-    entities: list[AquariteSelectEntity] = []
-
-    for dataservice in entry.runtime_data.coordinators.values():
-        entities.extend([
-            AquariteSelectEntity(
-                dataservice,
-                "Pump Mode", "pump_mode", "filtration.mode", PUMP_MODE_OPTIONS,
-            ),
-            AquariteSelectEntity(
-                dataservice,
-                "Pump Speed", "pump_speed", "filtration.manVel", PUMP_SPEED_OPTIONS,
-            ),
-        ])
-
-        for index in range(1, 4):
-            entities.append(
-                AquariteSelectEntity(
-                    dataservice,
-                    f"Filtration Timer Speed {index}",
-                    f"filtration_timer_speed_{index}",
-                    f"filtration.timerVel{index}",
-                    TIMER_SPEED_OPTIONS,
-                )
-            )
-
-    async_add_entities(entities)
+    async_add_entities(
+        AquariteSelect(coordinator, description)
+        for coordinator in entry.runtime_data.coordinators.values()
+        for description in SELECTS
+    )
 
 
-class AquariteSelectEntity(AquariteEntity, SelectEntity):
+class AquariteSelect(AquariteEntity, SelectEntity):
     """Aquarite select entity."""
+
+    entity_description: AquariteSelectEntityDescription
 
     def __init__(
         self,
-        dataservice: AquariteDataUpdateCoordinator,
-        name: str,
-        translation_key: str,
-        value_path: str,
-        options: tuple[str, ...],
+        coordinator: AquariteDataUpdateCoordinator,
+        description: AquariteSelectEntityDescription,
     ) -> None:
         """Initialize the select entity."""
-        super().__init__(dataservice)
-        self._value_path = value_path
-        self._options_map = options
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
-        self._attr_options = list(options)
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = self.build_unique_id(description.key)
 
     @property
     def current_option(self) -> str | None:
         """Return the current selected option."""
-        raw_value = self.coordinator.get_value(self._value_path)
+        raw = self.coordinator.get_value(self.entity_description.value_path)
         try:
-            return self._options_map[int(raw_value)]
+            return self.entity_description.options_map[int(raw)]
         except (TypeError, ValueError, IndexError):
             return None
 
@@ -84,8 +96,8 @@ class AquariteSelectEntity(AquariteEntity, SelectEntity):
         try:
             await self.coordinator.api.set_value(
                 self.coordinator.pool_id,
-                self._value_path,
-                self._options_map.index(option),
+                self.entity_description.value_path,
+                self.entity_description.options_map.index(option),
             )
         except Exception as err:
             raise HomeAssistantError(f"Failed to select option: {err}") from err

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -1,4 +1,5 @@
 """Aquarite Select entities."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/custom_components/aquarite/select.py
+++ b/custom_components/aquarite/select.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AquariteConfigEntry
 from .const import DOMAIN
@@ -58,7 +58,7 @@ SELECTS: tuple[AquariteSelectEntityDescription, ...] = (
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up select entities."""
     async_add_entities(

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -36,102 +36,102 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Aquarite sensors."""
-    dataservice = entry.runtime_data.coordinator
-    pool_id = dataservice.pool_id
-    pool_name = entry.title
-
     entities: list[AquariteEntity] = []
 
-    # Pool water temperature (the only read-only temperature; all setpoints
-    # are exposed as Number entities — see number.py)
-    entities.append(
-        AquariteTemperatureSensorEntity(
-            dataservice, pool_id, pool_name,
-            "Temperature", "temperature", "main.temperature",
-        )
-    )
+    for dataservice in entry.runtime_data.coordinators.values():
+        pool_id = dataservice.pool_id
+        pool_name = dataservice.pool_name
 
-    # Module Presence Sensors
-    if dataservice.get_value(PATH_HASCD):
+        # Pool water temperature (the only read-only temperature; all setpoints
+        # are exposed as Number entities — see number.py)
         entities.append(
-            AquariteValueSensorEntity(
-                dataservice, pool_id, pool_name, "CD", "cd", "modules.cd.current"
+            AquariteTemperatureSensorEntity(
+                dataservice, pool_id, pool_name,
+                "Temperature", "temperature", "main.temperature",
             )
         )
 
-    if dataservice.get_value(PATH_HASCL):
+        # Module Presence Sensors
+        if dataservice.get_value(PATH_HASCD):
+            entities.append(
+                AquariteValueSensorEntity(
+                    dataservice, pool_id, pool_name, "CD", "cd", "modules.cd.current"
+                )
+            )
+
+        if dataservice.get_value(PATH_HASCL):
+            entities.append(
+                AquariteValueSensorEntity(
+                    dataservice, pool_id, pool_name, "Cl", "cl", "modules.cl.current"
+                )
+            )
+
+        if dataservice.get_value(PATH_HASPH):
+            entities.append(
+                AquariteValueSensorEntity(
+                    dataservice, pool_id, pool_name, "pH", "ph",
+                    "modules.ph.current",
+                    device_class=SensorDeviceClass.PH,
+                )
+            )
+
+        if dataservice.get_value(PATH_HASRX):
+            entities.append(
+                AquariteRxValueSensorEntity(
+                    dataservice, pool_id, pool_name, "Rx", "rx", "modules.rx.current"
+                )
+            )
+
+        if dataservice.get_value(PATH_HASUV):
+            entities.append(
+                AquariteValueSensorEntity(
+                    dataservice, pool_id, pool_name, "UV", "uv", "modules.uv.current"
+                )
+            )
+
+        if dataservice.get_value(PATH_HASHIDRO):
+            is_electrolysis = dataservice.get_value("hidro.is_electrolysis")
+            name = "Electrolysis" if is_electrolysis else "Hidrolysis"
+            key = "electrolysis" if is_electrolysis else "hydrolysis"
+            entities.append(
+                AquariteHydrolyserSensorEntity(
+                    dataservice, pool_id, pool_name, name, key, "hidro.current"
+                )
+            )
+
+        # Wi-Fi signal strength (diagnostic, off by default — only useful on Wi-Fi controllers)
         entities.append(
-            AquariteValueSensorEntity(
-                dataservice, pool_id, pool_name, "Cl", "cl", "modules.cl.current"
+            AquariteRssiSensorEntity(dataservice, pool_id, pool_name)
+        )
+
+        # Time and Interval Sensors
+        entities.append(
+            AquariteTimeSensorEntity(
+                dataservice, pool_id, pool_name,
+                "Filtration Intel Time", "filtration_intel_time",
+                "filtration.intel.time",
+                native_unit_of_measurement="h",
             )
         )
 
-    if dataservice.get_value(PATH_HASPH):
-        entities.append(
-            AquariteValueSensorEntity(
-                dataservice, pool_id, pool_name, "pH", "ph",
-                "modules.ph.current",
-                device_class=SensorDeviceClass.PH,
+        # Location sensors (diagnostic)
+        for name, translation_key, key in (
+            ("City", "city", "city"),
+            ("Street", "street", "street"),
+            ("Zipcode", "zipcode", "zipcode"),
+            ("Country", "country", "country"),
+            ("Latitude", "latitude", "lat"),
+            ("Longitude", "longitude", "lng"),
+        ):
+            entities.append(
+                AquariteLocationSensorEntity(
+                    dataservice, pool_id, pool_name, name, translation_key, key
+                )
             )
-        )
 
-    if dataservice.get_value(PATH_HASRX):
         entities.append(
-            AquariteRxValueSensorEntity(
-                dataservice, pool_id, pool_name, "Rx", "rx", "modules.rx.current"
-            )
+            AquaritePoolNameSensorEntity(dataservice, pool_id, pool_name)
         )
-
-    if dataservice.get_value(PATH_HASUV):
-        entities.append(
-            AquariteValueSensorEntity(
-                dataservice, pool_id, pool_name, "UV", "uv", "modules.uv.current"
-            )
-        )
-
-    if dataservice.get_value(PATH_HASHIDRO):
-        is_electrolysis = dataservice.get_value("hidro.is_electrolysis")
-        name = "Electrolysis" if is_electrolysis else "Hidrolysis"
-        key = "electrolysis" if is_electrolysis else "hydrolysis"
-        entities.append(
-            AquariteHydrolyserSensorEntity(
-                dataservice, pool_id, pool_name, name, key, "hidro.current"
-            )
-        )
-
-    # Wi-Fi signal strength (diagnostic, off by default — only useful on Wi-Fi controllers)
-    entities.append(
-        AquariteRssiSensorEntity(dataservice, pool_id, pool_name)
-    )
-
-    # Time and Interval Sensors
-    entities.append(
-        AquariteTimeSensorEntity(
-            dataservice, pool_id, pool_name,
-            "Filtration Intel Time", "filtration_intel_time",
-            "filtration.intel.time",
-            native_unit_of_measurement="h",
-        )
-    )
-
-    # Location sensors (diagnostic)
-    for name, translation_key, key in (
-        ("City", "city", "city"),
-        ("Street", "street", "street"),
-        ("Zipcode", "zipcode", "zipcode"),
-        ("Country", "country", "country"),
-        ("Latitude", "latitude", "lat"),
-        ("Longitude", "longitude", "lng"),
-    ):
-        entities.append(
-            AquariteLocationSensorEntity(
-                dataservice, pool_id, pool_name, name, translation_key, key
-            )
-        )
-
-    entities.append(
-        AquaritePoolNameSensorEntity(dataservice, pool_id, pool_name)
-    )
 
     async_add_entities(entities)
 

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -94,14 +94,14 @@ SENSORS: tuple[AquariteSensorEntityDescription, ...] = (
         translation_key="cd",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_scaled("modules.cd.current", 100),
-        exists_fn=lambda c: bool(c.get_value(PATH_HASCD)),
+        exists_fn=lambda c: c.get_bool(PATH_HASCD),
     ),
     AquariteSensorEntityDescription(
         key="cl",
         translation_key="cl",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_scaled("modules.cl.current", 100),
-        exists_fn=lambda c: bool(c.get_value(PATH_HASCL)),
+        exists_fn=lambda c: c.get_bool(PATH_HASCL),
     ),
     AquariteSensorEntityDescription(
         key="ph",
@@ -109,7 +109,7 @@ SENSORS: tuple[AquariteSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.PH,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_scaled("modules.ph.current", 100),
-        exists_fn=lambda c: bool(c.get_value(PATH_HASPH)),
+        exists_fn=lambda c: c.get_bool(PATH_HASPH),
     ),
     AquariteSensorEntityDescription(
         key="rx",
@@ -117,14 +117,14 @@ SENSORS: tuple[AquariteSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_path("modules.rx.current", _coerce_int),
-        exists_fn=lambda c: bool(c.get_value(PATH_HASRX)),
+        exists_fn=lambda c: c.get_bool(PATH_HASRX),
     ),
     AquariteSensorEntityDescription(
         key="uv",
         translation_key="uv",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_scaled("modules.uv.current", 100),
-        exists_fn=lambda c: bool(c.get_value(PATH_HASUV)),
+        exists_fn=lambda c: c.get_bool(PATH_HASUV),
     ),
     AquariteSensorEntityDescription(
         key="filtration_intel_time",
@@ -189,7 +189,7 @@ SENSORS: tuple[AquariteSensorEntityDescription, ...] = (
 
 def _hidro_description(coordinator: AquariteDataUpdateCoordinator) -> AquariteSensorEntityDescription:
     """Return either electrolysis or hydrolysis description for the hidro module."""
-    is_electrolysis = bool(coordinator.get_value("hidro.is_electrolysis"))
+    is_electrolysis = coordinator.get_bool("hidro.is_electrolysis")
     key = "electrolysis" if is_electrolysis else "hydrolysis"
     return AquariteSensorEntityDescription(
         key=key,
@@ -215,7 +215,7 @@ async def async_setup_entry(
             if description.exists_fn is None or description.exists_fn(coordinator)
         )
 
-        if bool(coordinator.get_value(PATH_HASHIDRO)):
+        if coordinator.get_bool(PATH_HASHIDRO):
             entities.append(
                 AquariteSensor(coordinator, _hidro_description(coordinator))
             )

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -1,4 +1,5 @@
 """Aquarite Sensor entities."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -50,19 +51,25 @@ def _coerce_int(value: Any) -> int | None:
         return None
 
 
-def _scaled(path: str, divisor: float) -> Callable[[AquariteDataUpdateCoordinator], float | None]:
+def _scaled(
+    path: str, divisor: float
+) -> Callable[[AquariteDataUpdateCoordinator], float | None]:
     def _fn(coordinator: AquariteDataUpdateCoordinator) -> float | None:
         value = coordinator.get_value(path)
         try:
             return float(value) / divisor
         except (TypeError, ValueError):
             return None
+
     return _fn
 
 
-def _path(path: str, converter: Callable[[Any], Any] = _coerce_float) -> Callable[[AquariteDataUpdateCoordinator], Any]:
+def _path(
+    path: str, converter: Callable[[Any], Any] = _coerce_float
+) -> Callable[[AquariteDataUpdateCoordinator], Any]:
     def _fn(coordinator: AquariteDataUpdateCoordinator) -> Any:
         return converter(coordinator.get_value(path))
+
     return _fn
 
 
@@ -141,7 +148,9 @@ SENSORS: tuple[AquariteSensorEntityDescription, ...] = (
 )
 
 
-def _hidro_description(coordinator: AquariteDataUpdateCoordinator) -> AquariteSensorEntityDescription:
+def _hidro_description(
+    coordinator: AquariteDataUpdateCoordinator,
+) -> AquariteSensorEntityDescription:
     """Return either electrolysis or hydrolysis description for the hidro module."""
     is_electrolysis = coordinator.get_bool("hidro.is_electrolysis")
     key = "electrolysis" if is_electrolysis else "hydrolysis"

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -1,9 +1,14 @@
 """Aquarite Sensor entities."""
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
+    SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.const import (
@@ -30,316 +35,210 @@ from .entity import AquariteEntity
 PARALLEL_UPDATES = 1
 
 
+def _coerce_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _scaled(path: str, divisor: float) -> Callable[[AquariteDataUpdateCoordinator], float | None]:
+    def _fn(coordinator: AquariteDataUpdateCoordinator) -> float | None:
+        value = coordinator.get_value(path)
+        try:
+            return float(value) / divisor
+        except (TypeError, ValueError):
+            return None
+    return _fn
+
+
+def _path(path: str, converter: Callable[[Any], Any] = _coerce_float) -> Callable[[AquariteDataUpdateCoordinator], Any]:
+    def _fn(coordinator: AquariteDataUpdateCoordinator) -> Any:
+        return converter(coordinator.get_value(path))
+    return _fn
+
+
+def _form_field(field: str) -> Callable[[AquariteDataUpdateCoordinator], str | None]:
+    def _fn(coordinator: AquariteDataUpdateCoordinator) -> str | None:
+        form = coordinator.get_value("form")
+        return form.get(field) if form else None
+    return _fn
+
+
+@dataclass(frozen=True, kw_only=True)
+class AquariteSensorEntityDescription(SensorEntityDescription):
+    """Describes an Aquarite sensor."""
+
+    value_fn: Callable[[AquariteDataUpdateCoordinator], Any]
+    exists_fn: Callable[[AquariteDataUpdateCoordinator], bool] | None = None
+
+
+SENSORS: tuple[AquariteSensorEntityDescription, ...] = (
+    AquariteSensorEntityDescription(
+        key="temperature",
+        translation_key="temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_path("main.temperature"),
+    ),
+    AquariteSensorEntityDescription(
+        key="cd",
+        translation_key="cd",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_scaled("modules.cd.current", 100),
+        exists_fn=lambda c: bool(c.get_value(PATH_HASCD)),
+    ),
+    AquariteSensorEntityDescription(
+        key="cl",
+        translation_key="cl",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_scaled("modules.cl.current", 100),
+        exists_fn=lambda c: bool(c.get_value(PATH_HASCL)),
+    ),
+    AquariteSensorEntityDescription(
+        key="ph",
+        translation_key="ph",
+        device_class=SensorDeviceClass.PH,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_scaled("modules.ph.current", 100),
+        exists_fn=lambda c: bool(c.get_value(PATH_HASPH)),
+    ),
+    AquariteSensorEntityDescription(
+        key="rx",
+        translation_key="rx",
+        native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_path("modules.rx.current", _coerce_int),
+        exists_fn=lambda c: bool(c.get_value(PATH_HASRX)),
+    ),
+    AquariteSensorEntityDescription(
+        key="uv",
+        translation_key="uv",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_scaled("modules.uv.current", 100),
+        exists_fn=lambda c: bool(c.get_value(PATH_HASUV)),
+    ),
+    AquariteSensorEntityDescription(
+        key="filtration_intel_time",
+        translation_key="filtration_intel_time",
+        native_unit_of_measurement="h",
+        value_fn=_scaled("filtration.intel.time", 60),
+    ),
+    AquariteSensorEntityDescription(
+        key="city",
+        translation_key="city",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_form_field("city"),
+    ),
+    AquariteSensorEntityDescription(
+        key="street",
+        translation_key="street",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_form_field("street"),
+    ),
+    AquariteSensorEntityDescription(
+        key="zipcode",
+        translation_key="zipcode",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_form_field("zipcode"),
+    ),
+    AquariteSensorEntityDescription(
+        key="country",
+        translation_key="country",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_form_field("country"),
+    ),
+    AquariteSensorEntityDescription(
+        key="latitude",
+        translation_key="latitude",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_form_field("lat"),
+    ),
+    AquariteSensorEntityDescription(
+        key="longitude",
+        translation_key="longitude",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=_form_field("lng"),
+    ),
+    AquariteSensorEntityDescription(
+        key="pool_name",
+        translation_key="pool_name",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda c: c.pool_name,
+    ),
+    AquariteSensorEntityDescription(
+        key="rssi",
+        translation_key="rssi",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=_path("main.RSSI", _coerce_int),
+    ),
+)
+
+
+def _hidro_description(coordinator: AquariteDataUpdateCoordinator) -> AquariteSensorEntityDescription:
+    """Return either electrolysis or hydrolysis description for the hidro module."""
+    is_electrolysis = bool(coordinator.get_value("hidro.is_electrolysis"))
+    key = "electrolysis" if is_electrolysis else "hydrolysis"
+    return AquariteSensorEntityDescription(
+        key=key,
+        translation_key=key,
+        native_unit_of_measurement="gr/h",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=_scaled("hidro.current", 10),
+    )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Aquarite sensors."""
-    entities: list[AquariteEntity] = []
+    entities: list[AquariteSensor] = []
 
-    for dataservice in entry.runtime_data.coordinators.values():
-        # Pool water temperature (the only read-only temperature; all setpoints
-        # are exposed as Number entities — see number.py)
-        entities.append(
-            AquariteTemperatureSensorEntity(
-                dataservice, "Temperature", "temperature", "main.temperature",
-            )
+    for coordinator in entry.runtime_data.coordinators.values():
+        entities.extend(
+            AquariteSensor(coordinator, description)
+            for description in SENSORS
+            if description.exists_fn is None or description.exists_fn(coordinator)
         )
 
-        # Module Presence Sensors
-        if dataservice.get_value(PATH_HASCD):
+        if bool(coordinator.get_value(PATH_HASHIDRO)):
             entities.append(
-                AquariteValueSensorEntity(
-                    dataservice, "CD", "cd", "modules.cd.current"
-                )
+                AquariteSensor(coordinator, _hidro_description(coordinator))
             )
-
-        if dataservice.get_value(PATH_HASCL):
-            entities.append(
-                AquariteValueSensorEntity(
-                    dataservice, "Cl", "cl", "modules.cl.current"
-                )
-            )
-
-        if dataservice.get_value(PATH_HASPH):
-            entities.append(
-                AquariteValueSensorEntity(
-                    dataservice, "pH", "ph",
-                    "modules.ph.current",
-                    device_class=SensorDeviceClass.PH,
-                )
-            )
-
-        if dataservice.get_value(PATH_HASRX):
-            entities.append(
-                AquariteRxValueSensorEntity(
-                    dataservice, "Rx", "rx", "modules.rx.current"
-                )
-            )
-
-        if dataservice.get_value(PATH_HASUV):
-            entities.append(
-                AquariteValueSensorEntity(
-                    dataservice, "UV", "uv", "modules.uv.current"
-                )
-            )
-
-        if dataservice.get_value(PATH_HASHIDRO):
-            is_electrolysis = dataservice.get_value("hidro.is_electrolysis")
-            name = "Electrolysis" if is_electrolysis else "Hidrolysis"
-            key = "electrolysis" if is_electrolysis else "hydrolysis"
-            entities.append(
-                AquariteHydrolyserSensorEntity(
-                    dataservice, name, key, "hidro.current"
-                )
-            )
-
-        # Wi-Fi signal strength (diagnostic, off by default — only useful on Wi-Fi controllers)
-        entities.append(AquariteRssiSensorEntity(dataservice))
-
-        # Time and Interval Sensors
-        entities.append(
-            AquariteTimeSensorEntity(
-                dataservice,
-                "Filtration Intel Time", "filtration_intel_time",
-                "filtration.intel.time",
-                native_unit_of_measurement="h",
-            )
-        )
-
-        # Location sensors (diagnostic)
-        for name, translation_key, key in (
-            ("City", "city", "city"),
-            ("Street", "street", "street"),
-            ("Zipcode", "zipcode", "zipcode"),
-            ("Country", "country", "country"),
-            ("Latitude", "latitude", "lat"),
-            ("Longitude", "longitude", "lng"),
-        ):
-            entities.append(
-                AquariteLocationSensorEntity(
-                    dataservice, name, translation_key, key
-                )
-            )
-
-        entities.append(AquaritePoolNameSensorEntity(dataservice))
 
     async_add_entities(entities)
 
 
-class AquariteTemperatureSensorEntity(AquariteEntity, SensorEntity):
-    """Temperature sensor entity."""
+class AquariteSensor(AquariteEntity, SensorEntity):
+    """Aquarite sensor entity."""
 
-    _attr_device_class = SensorDeviceClass.TEMPERATURE
-    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    entity_description: AquariteSensorEntityDescription
 
     def __init__(
         self,
-        dataservice: AquariteDataUpdateCoordinator,
-        name: str,
-        translation_key: str,
-        value_path: str,
+        coordinator: AquariteDataUpdateCoordinator,
+        description: AquariteSensorEntityDescription,
     ) -> None:
-        """Initialize the temperature sensor."""
-        super().__init__(dataservice)
-        self._value_path = value_path
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = self.build_unique_id(description.key)
 
     @property
-    def native_value(self) -> float | None:
-        """Return the temperature value."""
-        value = self.coordinator.get_value(self._value_path)
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return None
-
-
-class AquariteValueSensorEntity(AquariteEntity, SensorEntity):
-    """Generic value sensor entity."""
-
-    _attr_state_class = SensorStateClass.MEASUREMENT
-
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        name: str,
-        translation_key: str,
-        value_path: str,
-        device_class: SensorDeviceClass | None = None,
-        native_unit_of_measurement: str | None = None,
-    ) -> None:
-        """Initialize the value sensor."""
-        super().__init__(dataservice)
-        self._value_path = value_path
-        self._attr_device_class = device_class
-        self._attr_native_unit_of_measurement = native_unit_of_measurement
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
-
-    @property
-    def native_value(self) -> float | None:
+    def native_value(self) -> Any:
         """Return the sensor value."""
-        value = self.coordinator.get_value(self._value_path)
-        try:
-            return float(value) / 100
-        except (TypeError, ValueError):
-            return None
-
-
-class AquariteTimeSensorEntity(AquariteEntity, SensorEntity):
-    """Time sensor entity."""
-
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        name: str,
-        translation_key: str,
-        value_path: str,
-        device_class: SensorDeviceClass | None = None,
-        native_unit_of_measurement: str | None = None,
-    ) -> None:
-        """Initialize the time sensor."""
-        super().__init__(dataservice)
-        self._value_path = value_path
-        self._attr_device_class = device_class
-        self._attr_native_unit_of_measurement = native_unit_of_measurement
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
-
-    @property
-    def native_value(self) -> float | None:
-        """Return the time value in hours."""
-        value = self.coordinator.get_value(self._value_path)
-        try:
-            return float(value) / 60
-        except (TypeError, ValueError):
-            return None
-
-
-class AquariteHydrolyserSensorEntity(AquariteEntity, SensorEntity):
-    """Hydrolyser sensor entity."""
-
-    _attr_native_unit_of_measurement = "gr/h"
-    _attr_state_class = SensorStateClass.MEASUREMENT
-
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        name: str,
-        translation_key: str,
-        value_path: str,
-    ) -> None:
-        """Initialize the hydrolyser sensor."""
-        super().__init__(dataservice)
-        self._value_path = value_path
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
-
-    @property
-    def native_value(self) -> float | None:
-        """Return the hydrolyser value."""
-        value = self.coordinator.get_value(self._value_path)
-        try:
-            return float(value) / 10
-        except (TypeError, ValueError):
-            return None
-
-
-class AquariteRxValueSensorEntity(AquariteEntity, SensorEntity):
-    """Redox value sensor entity."""
-
-    _attr_native_unit_of_measurement = UnitOfElectricPotential.MILLIVOLT
-    _attr_state_class = SensorStateClass.MEASUREMENT
-
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        name: str,
-        translation_key: str,
-        value_path: str,
-    ) -> None:
-        """Initialize the Rx sensor."""
-        super().__init__(dataservice)
-        self._value_path = value_path
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
-
-    @property
-    def native_value(self) -> int | None:
-        """Return the Rx value."""
-        value = self.coordinator.get_value(self._value_path)
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
-
-
-class AquariteLocationSensorEntity(AquariteEntity, SensorEntity):
-    """Location sensor entity."""
-
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        name: str,
-        translation_key: str,
-        form_key: str,
-    ) -> None:
-        """Initialize the location sensor."""
-        super().__init__(dataservice)
-        self._form_key = form_key
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
-
-    @property
-    def native_value(self) -> str | None:
-        """Return the location value."""
-        form = self.coordinator.get_value("form")
-        return form.get(self._form_key) if form else None
-
-
-class AquaritePoolNameSensorEntity(AquariteEntity, SensorEntity):
-    """Pool name sensor entity."""
-
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_translation_key = "pool_name"
-
-    def __init__(self, dataservice: AquariteDataUpdateCoordinator) -> None:
-        """Initialize the pool name sensor."""
-        super().__init__(dataservice)
-        self._attr_unique_id = self.build_unique_id("name")
-
-    @property
-    def native_value(self) -> str:
-        """Return the pool name."""
-        return self.coordinator.pool_name
-
-
-class AquariteRssiSensorEntity(AquariteEntity, SensorEntity):
-    """Controller Wi-Fi signal strength sensor."""
-
-    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
-    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_entity_registry_enabled_default = False
-    _attr_translation_key = "rssi"
-
-    def __init__(self, dataservice: AquariteDataUpdateCoordinator) -> None:
-        """Initialize the RSSI sensor."""
-        super().__init__(dataservice)
-        self._attr_unique_id = self.build_unique_id("RSSI")
-
-    @property
-    def native_value(self) -> int | None:
-        """Return the RSSI value."""
-        value = self.coordinator.get_value("main.RSSI")
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
+        return self.entity_description.value_fn(self.coordinator)

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -39,15 +39,11 @@ async def async_setup_entry(
     entities: list[AquariteEntity] = []
 
     for dataservice in entry.runtime_data.coordinators.values():
-        pool_id = dataservice.pool_id
-        pool_name = dataservice.pool_name
-
         # Pool water temperature (the only read-only temperature; all setpoints
         # are exposed as Number entities — see number.py)
         entities.append(
             AquariteTemperatureSensorEntity(
-                dataservice, pool_id, pool_name,
-                "Temperature", "temperature", "main.temperature",
+                dataservice, "Temperature", "temperature", "main.temperature",
             )
         )
 
@@ -55,21 +51,21 @@ async def async_setup_entry(
         if dataservice.get_value(PATH_HASCD):
             entities.append(
                 AquariteValueSensorEntity(
-                    dataservice, pool_id, pool_name, "CD", "cd", "modules.cd.current"
+                    dataservice, "CD", "cd", "modules.cd.current"
                 )
             )
 
         if dataservice.get_value(PATH_HASCL):
             entities.append(
                 AquariteValueSensorEntity(
-                    dataservice, pool_id, pool_name, "Cl", "cl", "modules.cl.current"
+                    dataservice, "Cl", "cl", "modules.cl.current"
                 )
             )
 
         if dataservice.get_value(PATH_HASPH):
             entities.append(
                 AquariteValueSensorEntity(
-                    dataservice, pool_id, pool_name, "pH", "ph",
+                    dataservice, "pH", "ph",
                     "modules.ph.current",
                     device_class=SensorDeviceClass.PH,
                 )
@@ -78,14 +74,14 @@ async def async_setup_entry(
         if dataservice.get_value(PATH_HASRX):
             entities.append(
                 AquariteRxValueSensorEntity(
-                    dataservice, pool_id, pool_name, "Rx", "rx", "modules.rx.current"
+                    dataservice, "Rx", "rx", "modules.rx.current"
                 )
             )
 
         if dataservice.get_value(PATH_HASUV):
             entities.append(
                 AquariteValueSensorEntity(
-                    dataservice, pool_id, pool_name, "UV", "uv", "modules.uv.current"
+                    dataservice, "UV", "uv", "modules.uv.current"
                 )
             )
 
@@ -95,19 +91,17 @@ async def async_setup_entry(
             key = "electrolysis" if is_electrolysis else "hydrolysis"
             entities.append(
                 AquariteHydrolyserSensorEntity(
-                    dataservice, pool_id, pool_name, name, key, "hidro.current"
+                    dataservice, name, key, "hidro.current"
                 )
             )
 
         # Wi-Fi signal strength (diagnostic, off by default — only useful on Wi-Fi controllers)
-        entities.append(
-            AquariteRssiSensorEntity(dataservice, pool_id, pool_name)
-        )
+        entities.append(AquariteRssiSensorEntity(dataservice))
 
         # Time and Interval Sensors
         entities.append(
             AquariteTimeSensorEntity(
-                dataservice, pool_id, pool_name,
+                dataservice,
                 "Filtration Intel Time", "filtration_intel_time",
                 "filtration.intel.time",
                 native_unit_of_measurement="h",
@@ -125,13 +119,11 @@ async def async_setup_entry(
         ):
             entities.append(
                 AquariteLocationSensorEntity(
-                    dataservice, pool_id, pool_name, name, translation_key, key
+                    dataservice, name, translation_key, key
                 )
             )
 
-        entities.append(
-            AquaritePoolNameSensorEntity(dataservice, pool_id, pool_name)
-        )
+        entities.append(AquaritePoolNameSensorEntity(dataservice))
 
     async_add_entities(entities)
 
@@ -146,14 +138,12 @@ class AquariteTemperatureSensorEntity(AquariteEntity, SensorEntity):
     def __init__(
         self,
         dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
         name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
         """Initialize the temperature sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._value_path = value_path
         self._attr_translation_key = translation_key
         self._attr_unique_id = self.build_unique_id(name)
@@ -176,8 +166,6 @@ class AquariteValueSensorEntity(AquariteEntity, SensorEntity):
     def __init__(
         self,
         dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
         name: str,
         translation_key: str,
         value_path: str,
@@ -185,7 +173,7 @@ class AquariteValueSensorEntity(AquariteEntity, SensorEntity):
         native_unit_of_measurement: str | None = None,
     ) -> None:
         """Initialize the value sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._value_path = value_path
         self._attr_device_class = device_class
         self._attr_native_unit_of_measurement = native_unit_of_measurement
@@ -208,8 +196,6 @@ class AquariteTimeSensorEntity(AquariteEntity, SensorEntity):
     def __init__(
         self,
         dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
         name: str,
         translation_key: str,
         value_path: str,
@@ -217,7 +203,7 @@ class AquariteTimeSensorEntity(AquariteEntity, SensorEntity):
         native_unit_of_measurement: str | None = None,
     ) -> None:
         """Initialize the time sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._value_path = value_path
         self._attr_device_class = device_class
         self._attr_native_unit_of_measurement = native_unit_of_measurement
@@ -243,14 +229,12 @@ class AquariteHydrolyserSensorEntity(AquariteEntity, SensorEntity):
     def __init__(
         self,
         dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
         name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
         """Initialize the hydrolyser sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._value_path = value_path
         self._attr_translation_key = translation_key
         self._attr_unique_id = self.build_unique_id(name)
@@ -274,14 +258,12 @@ class AquariteRxValueSensorEntity(AquariteEntity, SensorEntity):
     def __init__(
         self,
         dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
         name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
         """Initialize the Rx sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._value_path = value_path
         self._attr_translation_key = translation_key
         self._attr_unique_id = self.build_unique_id(name)
@@ -304,14 +286,12 @@ class AquariteLocationSensorEntity(AquariteEntity, SensorEntity):
     def __init__(
         self,
         dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
         name: str,
         translation_key: str,
         form_key: str,
     ) -> None:
         """Initialize the location sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._form_key = form_key
         self._attr_translation_key = translation_key
         self._attr_unique_id = self.build_unique_id(name)
@@ -327,22 +307,17 @@ class AquaritePoolNameSensorEntity(AquariteEntity, SensorEntity):
     """Pool name sensor entity."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "pool_name"
 
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
-    ) -> None:
+    def __init__(self, dataservice: AquariteDataUpdateCoordinator) -> None:
         """Initialize the pool name sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
-        self._attr_translation_key = "pool_name"
+        super().__init__(dataservice)
         self._attr_unique_id = self.build_unique_id("name")
 
     @property
     def native_value(self) -> str:
         """Return the pool name."""
-        return self._pool_name
+        return self.coordinator.pool_name
 
 
 class AquariteRssiSensorEntity(AquariteEntity, SensorEntity):
@@ -353,16 +328,11 @@ class AquariteRssiSensorEntity(AquariteEntity, SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
+    _attr_translation_key = "rssi"
 
-    def __init__(
-        self,
-        dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
-    ) -> None:
+    def __init__(self, dataservice: AquariteDataUpdateCoordinator) -> None:
         """Initialize the RSSI sensor."""
-        super().__init__(dataservice, pool_id, pool_name)
-        self._attr_translation_key = "rssi"
+        super().__init__(dataservice)
         self._attr_unique_id = self.build_unique_id("RSSI")
 
     @property

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -16,9 +16,10 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfElectricPotential,
     UnitOfTemperature,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AquariteConfigEntry
 from .const import (
@@ -122,7 +123,9 @@ SENSORS: tuple[AquariteSensorEntityDescription, ...] = (
     AquariteSensorEntityDescription(
         key="filtration_intel_time",
         translation_key="filtration_intel_time",
-        native_unit_of_measurement="h",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTime.HOURS,
         value_fn=_scaled("filtration.intel.time", 60),
     ),
     AquariteSensorEntityDescription(
@@ -145,7 +148,7 @@ def _hidro_description(coordinator: AquariteDataUpdateCoordinator) -> AquariteSe
     return AquariteSensorEntityDescription(
         key=key,
         translation_key=key,
-        native_unit_of_measurement="gr/h",
+        native_unit_of_measurement="g/h",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=_scaled("hidro.current", 10),
     )
@@ -154,7 +157,7 @@ def _hidro_description(coordinator: AquariteDataUpdateCoordinator) -> AquariteSe
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Aquarite sensors."""
     entities: list[AquariteSensor] = []

--- a/custom_components/aquarite/sensor.py
+++ b/custom_components/aquarite/sensor.py
@@ -65,13 +65,6 @@ def _path(path: str, converter: Callable[[Any], Any] = _coerce_float) -> Callabl
     return _fn
 
 
-def _form_field(field: str) -> Callable[[AquariteDataUpdateCoordinator], str | None]:
-    def _fn(coordinator: AquariteDataUpdateCoordinator) -> str | None:
-        form = coordinator.get_value("form")
-        return form.get(field) if form else None
-    return _fn
-
-
 @dataclass(frozen=True, kw_only=True)
 class AquariteSensorEntityDescription(SensorEntityDescription):
     """Describes an Aquarite sensor."""
@@ -131,48 +124,6 @@ SENSORS: tuple[AquariteSensorEntityDescription, ...] = (
         translation_key="filtration_intel_time",
         native_unit_of_measurement="h",
         value_fn=_scaled("filtration.intel.time", 60),
-    ),
-    AquariteSensorEntityDescription(
-        key="city",
-        translation_key="city",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=_form_field("city"),
-    ),
-    AquariteSensorEntityDescription(
-        key="street",
-        translation_key="street",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=_form_field("street"),
-    ),
-    AquariteSensorEntityDescription(
-        key="zipcode",
-        translation_key="zipcode",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=_form_field("zipcode"),
-    ),
-    AquariteSensorEntityDescription(
-        key="country",
-        translation_key="country",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=_form_field("country"),
-    ),
-    AquariteSensorEntityDescription(
-        key="latitude",
-        translation_key="latitude",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=_form_field("lat"),
-    ),
-    AquariteSensorEntityDescription(
-        key="longitude",
-        translation_key="longitude",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=_form_field("lng"),
-    ),
-    AquariteSensorEntityDescription(
-        key="pool_name",
-        translation_key="pool_name",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda c: c.pool_name,
     ),
     AquariteSensorEntityDescription(
         key="rssi",

--- a/custom_components/aquarite/strings.json
+++ b/custom_components/aquarite/strings.json
@@ -17,13 +17,6 @@
         "description": "Re-authenticate your Hayward account to continue.",
         "title": "[%key:common::config_flow::title::reauth%]"
       },
-      "pool": {
-        "data": {
-          "pool_id": "Pool"
-        },
-        "description": "Please choose the pool for this integration.",
-        "title": "Select Pool"
-      },
       "reconfigure": {
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
@@ -34,24 +27,13 @@
       }
     },
     "error": {
-      "auth_error": "Authorization failed, check username and password.",
-      "no_pools_found": "No pools found for your account.",
-      "unknown_error": "Unexpected error. Please try again."
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "data": {
-          "health_check_interval": "Health check interval (seconds)"
-        },
-        "description": "Configure the Aquarite integration.",
-        "title": "Options"
-      }
     }
   },
   "entity": {

--- a/custom_components/aquarite/strings.json
+++ b/custom_components/aquarite/strings.json
@@ -1,89 +1,60 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+    },
+    "error": {
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
     "step": {
-      "user": {
-        "data": {
-          "username": "Hayward Username",
-          "password": "Password"
-        },
-        "description": "Enter your Hayward credentials.",
-        "title": "Authentication"
-      },
       "reauth_confirm": {
         "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "Password for your Hayward account.",
+          "username": "Email address or username registered with Hayward."
         },
         "description": "Re-authenticate your Hayward account to continue.",
         "title": "[%key:common::config_flow::title::reauth%]"
       },
       "reconfigure": {
         "data": {
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "[%key:component::aquarite::config::step::reauth_confirm::data_description::password%]",
+          "username": "[%key:component::aquarite::config::step::reauth_confirm::data_description::username%]"
         },
         "description": "Update your Hayward credentials.",
         "title": "Reconfigure"
+      },
+      "user": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "[%key:component::aquarite::config::step::reauth_confirm::data_description::password%]",
+          "username": "[%key:component::aquarite::config::step::reauth_confirm::data_description::username%]"
+        },
+        "description": "Enter your Hayward credentials. All pools linked to the account will be discovered automatically.",
+        "title": "Authentication"
       }
-    },
-    "error": {
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "entity": {
-    "sensor": {
-      "temperature": {
-        "name": "Temperature"
-      },
-      "cd": {
-        "name": "CD"
-      },
-      "cl": {
-        "name": "CL"
-      },
-      "ph": {
-        "name": "pH"
-      },
-      "rx": {
-        "name": "Rx"
-      },
-      "uv": {
-        "name": "UV"
-      },
-      "electrolysis": {
-        "name": "Electrolysis"
-      },
-      "hydrolysis": {
-        "name": "Hydrolysis"
-      },
-      "filtration_intel_time": {
-        "name": "Filtration intel time"
-      },
-      "rssi": {
-        "name": "Wi-Fi signal strength"
-      }
-    },
     "binary_sensor": {
-      "hidro_flow_status": {
-        "name": "Hydrolysis flow status"
-      },
-      "filtration_status": {
-        "name": "Filtration status"
+      "acid_tank": {
+        "name": "Acid tank"
       },
       "backwash_status": {
         "name": "Backwash status"
-      },
-      "hidro_cover_reduction": {
-        "name": "Hydrolysis cover reduction"
-      },
-      "ph_pump_alarm": {
-        "name": "pH pump alarm"
       },
       "cd_module_installed": {
         "name": "CD module installed"
@@ -91,17 +62,38 @@
       "cl_module_installed": {
         "name": "CL module installed"
       },
-      "rx_module_installed": {
-        "name": "RX module installed"
+      "cl_pump_status": {
+        "name": "Chlorine pump status"
       },
-      "ph_module_installed": {
-        "name": "pH module installed"
+      "connected": {
+        "name": "Connected"
       },
-      "io_module_installed": {
-        "name": "IO module installed"
+      "electrolysis_low": {
+        "name": "Electrolysis low"
+      },
+      "filtration_status": {
+        "name": "Filtration status"
+      },
+      "heating_status": {
+        "name": "Heating status"
+      },
+      "hidro_cover_reduction": {
+        "name": "Hydrolysis cover reduction"
+      },
+      "hidro_fl2_status": {
+        "name": "Hydrolysis FL2 status"
+      },
+      "hidro_flow_status": {
+        "name": "Hydrolysis flow status"
       },
       "hidro_module_installed": {
         "name": "Hydrolysis module installed"
+      },
+      "hydrolysis_low": {
+        "name": "Hydrolysis low"
+      },
+      "io_module_installed": {
+        "name": "IO module installed"
       },
       "ph_acid_pump": {
         "name": "pH acid pump"
@@ -109,37 +101,151 @@
       "ph_base_pump": {
         "name": "pH base pump"
       },
-      "cl_pump_status": {
-        "name": "Chlorine pump status"
+      "ph_module_installed": {
+        "name": "pH module installed"
+      },
+      "ph_pump_alarm": {
+        "name": "pH pump alarm"
+      },
+      "rx_module_installed": {
+        "name": "RX module installed"
       },
       "rx_pump_status": {
         "name": "Rx pump status"
+      }
+    },
+    "button": {
+      "led_pulse": {
+        "name": "LED pulse"
+      }
+    },
+    "device_tracker": {
+      "location": {
+        "name": "Location"
+      }
+    },
+    "light": {
+      "pool_light": {
+        "name": "Light"
+      }
+    },
+    "number": {
+      "electrolysis_setpoint": {
+        "name": "Electrolysis setpoint"
       },
-      "heating_status": {
-        "name": "Heating status"
+      "heating_mode_max_temperature": {
+        "name": "Heating mode max temperature"
       },
-      "connected": {
-        "name": "Connected"
+      "heating_mode_min_temperature": {
+        "name": "Heating mode min temperature"
       },
-      "hidro_fl2_status": {
-        "name": "Hydrolysis FL2 status"
+      "intel_mode_temperature": {
+        "name": "Intel mode temperature"
       },
-      "acid_tank": {
-        "name": "Acid tank"
+      "ph_low": {
+        "name": "pH low"
       },
-      "electrolysis_low": {
-        "name": "Electrolysis low"
+      "ph_max": {
+        "name": "pH max"
       },
-      "hydrolysis_low": {
-        "name": "Hydrolysis low"
+      "redox_setpoint": {
+        "name": "Redox setpoint"
+      },
+      "smart_mode_max_temperature": {
+        "name": "Smart mode max temperature"
+      },
+      "smart_mode_min_temperature": {
+        "name": "Smart mode min temperature"
+      }
+    },
+    "select": {
+      "filtration_timer_speed_1": {
+        "name": "Filtration timer speed 1",
+        "state": {
+          "high": "High",
+          "medium": "Medium",
+          "slow": "Slow"
+        }
+      },
+      "filtration_timer_speed_2": {
+        "name": "Filtration timer speed 2",
+        "state": {
+          "high": "[%key:component::aquarite::entity::select::filtration_timer_speed_1::state::high%]",
+          "medium": "[%key:component::aquarite::entity::select::filtration_timer_speed_1::state::medium%]",
+          "slow": "[%key:component::aquarite::entity::select::filtration_timer_speed_1::state::slow%]"
+        }
+      },
+      "filtration_timer_speed_3": {
+        "name": "Filtration timer speed 3",
+        "state": {
+          "high": "[%key:component::aquarite::entity::select::filtration_timer_speed_1::state::high%]",
+          "medium": "[%key:component::aquarite::entity::select::filtration_timer_speed_1::state::medium%]",
+          "slow": "[%key:component::aquarite::entity::select::filtration_timer_speed_1::state::slow%]"
+        }
+      },
+      "pump_mode": {
+        "name": "Pump mode",
+        "state": {
+          "auto": "Auto",
+          "heat": "Heat",
+          "intel": "Intel",
+          "manual": "Manual",
+          "smart": "Smart"
+        }
+      },
+      "pump_speed": {
+        "name": "Pump speed",
+        "state": {
+          "high": "[%key:component::aquarite::entity::select::filtration_timer_speed_1::state::high%]",
+          "medium": "[%key:component::aquarite::entity::select::filtration_timer_speed_1::state::medium%]",
+          "slow": "[%key:component::aquarite::entity::select::filtration_timer_speed_1::state::slow%]"
+        }
+      }
+    },
+    "sensor": {
+      "cd": {
+        "name": "CD"
+      },
+      "cl": {
+        "name": "CL"
+      },
+      "electrolysis": {
+        "name": "Electrolysis"
+      },
+      "filtration_intel_time": {
+        "name": "Filtration intel time"
+      },
+      "hydrolysis": {
+        "name": "Hydrolysis"
+      },
+      "ph": {
+        "name": "pH"
+      },
+      "rssi": {
+        "name": "Wi-Fi signal strength"
+      },
+      "rx": {
+        "name": "Rx"
+      },
+      "temperature": {
+        "name": "Temperature"
+      },
+      "uv": {
+        "name": "UV"
       }
     },
     "switch": {
+      "electrolysis_boost": {
+        "name": "Electrolysis boost"
+      },
       "electrolysis_cover": {
         "name": "Electrolysis cover"
       },
-      "electrolysis_boost": {
-        "name": "Electrolysis boost"
+      "filtration": {
+        "name": "Filtration"
+      },
+      "heating_climate": {
+        "name": "Heating climate"
       },
       "relay_1": {
         "name": "Relay 1"
@@ -153,87 +259,8 @@
       "relay_4": {
         "name": "Relay 4"
       },
-      "filtration": {
-        "name": "Filtration"
-      },
-      "heating_climate": {
-        "name": "Heating climate"
-      },
       "smart_mode_freeze": {
         "name": "Smart mode freeze protection"
-      }
-    },
-    "number": {
-      "redox_setpoint": {
-        "name": "Redox setpoint"
-      },
-      "ph_low": {
-        "name": "pH low"
-      },
-      "ph_max": {
-        "name": "pH max"
-      },
-      "electrolysis_setpoint": {
-        "name": "Electrolysis setpoint"
-      },
-      "intel_mode_temperature": {
-        "name": "Intel mode temperature"
-      },
-      "heating_mode_min_temperature": {
-        "name": "Heating mode min temperature"
-      },
-      "heating_mode_max_temperature": {
-        "name": "Heating mode max temperature"
-      },
-      "smart_mode_min_temperature": {
-        "name": "Smart mode min temperature"
-      },
-      "smart_mode_max_temperature": {
-        "name": "Smart mode max temperature"
-      }
-    },
-    "select": {
-      "pump_mode": {
-        "name": "Pump mode",
-        "state": {
-          "manual": "Manual",
-          "auto": "Auto",
-          "heat": "Heat",
-          "smart": "Smart",
-          "intel": "Intel"
-        }
-      },
-      "pump_speed": {
-        "name": "Pump speed",
-        "state": {
-          "slow": "Slow",
-          "medium": "Medium",
-          "high": "High"
-        }
-      },
-      "filtration_timer_speed_1": {
-        "name": "Filtration timer speed 1",
-        "state": {
-          "slow": "Slow",
-          "medium": "Medium",
-          "high": "High"
-        }
-      },
-      "filtration_timer_speed_2": {
-        "name": "Filtration timer speed 2",
-        "state": {
-          "slow": "Slow",
-          "medium": "Medium",
-          "high": "High"
-        }
-      },
-      "filtration_timer_speed_3": {
-        "name": "Filtration timer speed 3",
-        "state": {
-          "slow": "Slow",
-          "medium": "Medium",
-          "high": "High"
-        }
       }
     },
     "time": {
@@ -255,35 +282,20 @@
       "filtration_interval_3_to": {
         "name": "Filtration interval 3 to"
       }
-    },
-    "light": {
-      "pool_light": {
-        "name": "Light"
-      }
-    },
-    "button": {
-      "led_pulse": {
-        "name": "LED pulse"
-      }
-    },
-    "device_tracker": {
-      "location": {
-        "name": "Location"
-      }
     }
   },
   "exceptions": {
-    "communication_error": {
-      "message": "An error occurred while communicating with the Aquarite device: {error}"
-    },
     "authentication_error": {
       "message": "Authentication failed. Please check your credentials."
+    },
+    "communication_error": {
+      "message": "Error communicating with the Aquarite device: {error}"
     }
   },
   "services": {
     "sync_pool_time": {
-      "name": "Sync pool time",
-      "description": "Sync the Home Assistant date and time to the pool controller."
+      "description": "Syncs the Home Assistant date and time to the pool controller.",
+      "name": "Sync pool time"
     }
   }
 }

--- a/custom_components/aquarite/strings.json
+++ b/custom_components/aquarite/strings.json
@@ -65,27 +65,6 @@
       "filtration_intel_time": {
         "name": "Filtration intel time"
       },
-      "city": {
-        "name": "City"
-      },
-      "street": {
-        "name": "Street"
-      },
-      "zipcode": {
-        "name": "Zipcode"
-      },
-      "country": {
-        "name": "Country"
-      },
-      "latitude": {
-        "name": "Latitude"
-      },
-      "longitude": {
-        "name": "Longitude"
-      },
-      "pool_name": {
-        "name": "Pool name"
-      },
       "rssi": {
         "name": "Wi-Fi signal strength"
       }

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -1,4 +1,5 @@
 """Aquarite Switch entities."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -119,9 +120,7 @@ class AquariteSwitch(AquariteEntity, SwitchEntity):
         path = self.entity_description.value_path
         onoff = self.coordinator.get_bool(path)
         if self.entity_description.is_relay:
-            return onoff or self.coordinator.get_bool(
-                path.replace("onoff", "status")
-            )
+            return onoff or self.coordinator.get_bool(path.replace("onoff", "status"))
         return onoff
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from aioaquarite import AquariteError
+
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -135,7 +137,7 @@ class AquariteSwitch(AquariteEntity, SwitchEntity):
             await self.coordinator.api.set_value(
                 self.coordinator.pool_id, self.entity_description.value_path, value
             )
-        except Exception as err:
+        except AquariteError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -11,6 +11,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AquariteConfigEntry
+from .const import DOMAIN
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
@@ -135,4 +136,8 @@ class AquariteSwitch(AquariteEntity, SwitchEntity):
                 self.coordinator.pool_id, self.entity_description.value_path, value
             )
         except Exception as err:
-            raise HomeAssistantError(f"Failed to set switch: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -70,13 +70,13 @@ SWITCHES: tuple[AquariteSwitchEntityDescription, ...] = (
         key="heating_climate",
         translation_key="heating_climate",
         value_path="filtration.heating.clima",
-        exists_fn=lambda c: bool(c.get_value("filtration.hasHeat")),
+        exists_fn=lambda c: c.get_bool("filtration.hasHeat"),
     ),
     AquariteSwitchEntityDescription(
         key="smart_mode_freeze",
         translation_key="smart_mode_freeze",
         value_path="filtration.smart.freeze",
-        exists_fn=lambda c: bool(c.get_value("filtration.hasSmart")),
+        exists_fn=lambda c: c.get_bool("filtration.hasSmart"),
     ),
 )
 
@@ -114,12 +114,11 @@ class AquariteSwitch(AquariteEntity, SwitchEntity):
     def is_on(self) -> bool:
         """Return true if switch is on."""
         path = self.entity_description.value_path
-        onoff = bool(self.coordinator.get_value(path))
+        onoff = self.coordinator.get_bool(path)
         if self.entity_description.is_relay:
-            status = bool(
-                self.coordinator.get_value(path.replace("onoff", "status"))
+            return onoff or self.coordinator.get_bool(
+                path.replace("onoff", "status")
             )
-            return onoff or status
         return onoff
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -8,7 +8,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AquariteConfigEntry
 from .const import DOMAIN
@@ -85,7 +85,7 @@ SWITCHES: tuple[AquariteSwitchEntityDescription, ...] = (
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Aquarite switch platform."""
     async_add_entities(

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -44,38 +44,40 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Aquarite switch platform."""
-    dataservice = entry.runtime_data.coordinator
-    pool_id, pool_name = dataservice.pool_id, entry.title
+    entities: list[AquariteSwitchEntity] = []
 
-    entities = [
-        AquariteSwitchEntity(dataservice, pool_id, pool_name, config)
-        for config in SWITCH_DEFINITIONS
-    ]
+    for dataservice in entry.runtime_data.coordinators.values():
+        pool_id, pool_name = dataservice.pool_id, dataservice.pool_name
 
-    # HEAT mode "Climat" toggle (visible under the HEAT slider position in
-    # the Hayward app).
-    if dataservice.get_value("filtration.hasHeat"):
-        entities.append(
-            AquariteSwitchEntity(
-                dataservice, pool_id, pool_name,
-                AquariteSwitchConfig(
-                    "Heating Climate", "heating_climate", "filtration.heating.clima",
-                ),
-            )
+        entities.extend(
+            AquariteSwitchEntity(dataservice, pool_id, pool_name, config)
+            for config in SWITCH_DEFINITIONS
         )
 
-    # SMART mode "Antigel" (freeze protection) toggle. Replaces the read-only
-    # binary sensor that previously exposed `filtration.smart.freeze` —
-    # see PR description for the breaking-change note.
-    if dataservice.get_value("filtration.hasSmart"):
-        entities.append(
-            AquariteSwitchEntity(
-                dataservice, pool_id, pool_name,
-                AquariteSwitchConfig(
-                    "Smart Mode Freeze", "smart_mode_freeze", "filtration.smart.freeze",
-                ),
+        # HEAT mode "Climat" toggle (visible under the HEAT slider position in
+        # the Hayward app).
+        if dataservice.get_value("filtration.hasHeat"):
+            entities.append(
+                AquariteSwitchEntity(
+                    dataservice, pool_id, pool_name,
+                    AquariteSwitchConfig(
+                        "Heating Climate", "heating_climate", "filtration.heating.clima",
+                    ),
+                )
             )
-        )
+
+        # SMART mode "Antigel" (freeze protection) toggle. Replaces the read-only
+        # binary sensor that previously exposed `filtration.smart.freeze` —
+        # see PR description for the breaking-change note.
+        if dataservice.get_value("filtration.hasSmart"):
+            entities.append(
+                AquariteSwitchEntity(
+                    dataservice, pool_id, pool_name,
+                    AquariteSwitchConfig(
+                        "Smart Mode Freeze", "smart_mode_freeze", "filtration.smart.freeze",
+                    ),
+                )
+            )
 
     async_add_entities(entities)
 

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -1,11 +1,11 @@
 """Aquarite Switch entities."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-
 from typing import Any
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -14,28 +14,71 @@ from . import AquariteConfigEntry
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
+PARALLEL_UPDATES = 1
 
-@dataclass(frozen=True)
-class AquariteSwitchConfig:
-    """Configuration for an Aquarite switch."""
 
-    name: str
-    translation_key: str
+@dataclass(frozen=True, kw_only=True)
+class AquariteSwitchEntityDescription(SwitchEntityDescription):
+    """Describes an Aquarite switch."""
+
     value_path: str
     is_relay: bool = False
+    exists_fn: Callable[[AquariteDataUpdateCoordinator], bool] | None = None
 
 
-SWITCH_DEFINITIONS: tuple[AquariteSwitchConfig, ...] = (
-    AquariteSwitchConfig("Electrolysis Cover", "electrolysis_cover", "hidro.cover_enabled"),
-    AquariteSwitchConfig("Electrolysis Boost", "electrolysis_boost", "hidro.cloration_enabled"),
-    AquariteSwitchConfig("Relay1", "relay_1", "relays.relay1.info.onoff", is_relay=True),
-    AquariteSwitchConfig("Relay2", "relay_2", "relays.relay2.info.onoff", is_relay=True),
-    AquariteSwitchConfig("Relay3", "relay_3", "relays.relay3.info.onoff", is_relay=True),
-    AquariteSwitchConfig("Relay4", "relay_4", "relays.relay4.info.onoff", is_relay=True),
-    AquariteSwitchConfig("Filtration Status", "filtration", "filtration.status"),
+SWITCHES: tuple[AquariteSwitchEntityDescription, ...] = (
+    AquariteSwitchEntityDescription(
+        key="electrolysis_cover",
+        translation_key="electrolysis_cover",
+        value_path="hidro.cover_enabled",
+    ),
+    AquariteSwitchEntityDescription(
+        key="electrolysis_boost",
+        translation_key="electrolysis_boost",
+        value_path="hidro.cloration_enabled",
+    ),
+    AquariteSwitchEntityDescription(
+        key="relay_1",
+        translation_key="relay_1",
+        value_path="relays.relay1.info.onoff",
+        is_relay=True,
+    ),
+    AquariteSwitchEntityDescription(
+        key="relay_2",
+        translation_key="relay_2",
+        value_path="relays.relay2.info.onoff",
+        is_relay=True,
+    ),
+    AquariteSwitchEntityDescription(
+        key="relay_3",
+        translation_key="relay_3",
+        value_path="relays.relay3.info.onoff",
+        is_relay=True,
+    ),
+    AquariteSwitchEntityDescription(
+        key="relay_4",
+        translation_key="relay_4",
+        value_path="relays.relay4.info.onoff",
+        is_relay=True,
+    ),
+    AquariteSwitchEntityDescription(
+        key="filtration",
+        translation_key="filtration",
+        value_path="filtration.status",
+    ),
+    AquariteSwitchEntityDescription(
+        key="heating_climate",
+        translation_key="heating_climate",
+        value_path="filtration.heating.clima",
+        exists_fn=lambda c: bool(c.get_value("filtration.hasHeat")),
+    ),
+    AquariteSwitchEntityDescription(
+        key="smart_mode_freeze",
+        translation_key="smart_mode_freeze",
+        value_path="filtration.smart.freeze",
+        exists_fn=lambda c: bool(c.get_value("filtration.hasSmart")),
+    ),
 )
-
-PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
@@ -44,81 +87,53 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Aquarite switch platform."""
-    entities: list[AquariteSwitchEntity] = []
-
-    for dataservice in entry.runtime_data.coordinators.values():
-        entities.extend(
-            AquariteSwitchEntity(dataservice, config)
-            for config in SWITCH_DEFINITIONS
-        )
-
-        # HEAT mode "Climat" toggle (visible under the HEAT slider position in
-        # the Hayward app).
-        if dataservice.get_value("filtration.hasHeat"):
-            entities.append(
-                AquariteSwitchEntity(
-                    dataservice,
-                    AquariteSwitchConfig(
-                        "Heating Climate", "heating_climate", "filtration.heating.clima",
-                    ),
-                )
-            )
-
-        # SMART mode "Antigel" (freeze protection) toggle. Replaces the read-only
-        # binary sensor that previously exposed `filtration.smart.freeze` —
-        # see PR description for the breaking-change note.
-        if dataservice.get_value("filtration.hasSmart"):
-            entities.append(
-                AquariteSwitchEntity(
-                    dataservice,
-                    AquariteSwitchConfig(
-                        "Smart Mode Freeze", "smart_mode_freeze", "filtration.smart.freeze",
-                    ),
-                )
-            )
-
-    async_add_entities(entities)
+    async_add_entities(
+        AquariteSwitch(coordinator, description)
+        for coordinator in entry.runtime_data.coordinators.values()
+        for description in SWITCHES
+        if description.exists_fn is None or description.exists_fn(coordinator)
+    )
 
 
-class AquariteSwitchEntity(AquariteEntity, SwitchEntity):
-    """Representation of an Aquarite switch."""
+class AquariteSwitch(AquariteEntity, SwitchEntity):
+    """Aquarite switch entity."""
+
+    entity_description: AquariteSwitchEntityDescription
 
     def __init__(
         self,
         coordinator: AquariteDataUpdateCoordinator,
-        config: AquariteSwitchConfig,
+        description: AquariteSwitchEntityDescription,
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator)
-        self._value_path = config.value_path
-        self._is_relay = config.is_relay
-        self._attr_translation_key = config.translation_key
-        self._attr_unique_id = self.build_unique_id(config.name)
+        self.entity_description = description
+        self._attr_unique_id = self.build_unique_id(description.key)
 
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
-        onoff = bool(self.coordinator.get_value(self._value_path))
-        if self._is_relay:
-            status_path = self._value_path.replace("onoff", "status")
-            status = bool(self.coordinator.get_value(status_path))
+        path = self.entity_description.value_path
+        onoff = bool(self.coordinator.get_value(path))
+        if self.entity_description.is_relay:
+            status = bool(
+                self.coordinator.get_value(path.replace("onoff", "status"))
+            )
             return onoff or status
         return onoff
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        try:
-            await self.coordinator.api.set_value(
-                self.coordinator.pool_id, self._value_path, 1
-            )
-        except Exception as err:
-            raise HomeAssistantError(f"Failed to turn on: {err}") from err
+        await self._async_set(1)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
+        await self._async_set(0)
+
+    async def _async_set(self, value: int) -> None:
         try:
             await self.coordinator.api.set_value(
-                self.coordinator.pool_id, self._value_path, 0
+                self.coordinator.pool_id, self.entity_description.value_path, value
             )
         except Exception as err:
-            raise HomeAssistantError(f"Failed to turn off: {err}") from err
+            raise HomeAssistantError(f"Failed to set switch: {err}") from err

--- a/custom_components/aquarite/switch.py
+++ b/custom_components/aquarite/switch.py
@@ -47,10 +47,8 @@ async def async_setup_entry(
     entities: list[AquariteSwitchEntity] = []
 
     for dataservice in entry.runtime_data.coordinators.values():
-        pool_id, pool_name = dataservice.pool_id, dataservice.pool_name
-
         entities.extend(
-            AquariteSwitchEntity(dataservice, pool_id, pool_name, config)
+            AquariteSwitchEntity(dataservice, config)
             for config in SWITCH_DEFINITIONS
         )
 
@@ -59,7 +57,7 @@ async def async_setup_entry(
         if dataservice.get_value("filtration.hasHeat"):
             entities.append(
                 AquariteSwitchEntity(
-                    dataservice, pool_id, pool_name,
+                    dataservice,
                     AquariteSwitchConfig(
                         "Heating Climate", "heating_climate", "filtration.heating.clima",
                     ),
@@ -72,7 +70,7 @@ async def async_setup_entry(
         if dataservice.get_value("filtration.hasSmart"):
             entities.append(
                 AquariteSwitchEntity(
-                    dataservice, pool_id, pool_name,
+                    dataservice,
                     AquariteSwitchConfig(
                         "Smart Mode Freeze", "smart_mode_freeze", "filtration.smart.freeze",
                     ),
@@ -88,12 +86,10 @@ class AquariteSwitchEntity(AquariteEntity, SwitchEntity):
     def __init__(
         self,
         coordinator: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
         config: AquariteSwitchConfig,
     ) -> None:
         """Initialize the switch."""
-        super().__init__(coordinator, pool_id, pool_name)
+        super().__init__(coordinator)
         self._value_path = config.value_path
         self._is_relay = config.is_relay
         self._attr_translation_key = config.translation_key
@@ -112,13 +108,17 @@ class AquariteSwitchEntity(AquariteEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         try:
-            await self.coordinator.api.set_value(self._pool_id, self._value_path, 1)
+            await self.coordinator.api.set_value(
+                self.coordinator.pool_id, self._value_path, 1
+            )
         except Exception as err:
             raise HomeAssistantError(f"Failed to turn on: {err}") from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         try:
-            await self.coordinator.api.set_value(self._pool_id, self._value_path, 0)
+            await self.coordinator.api.set_value(
+                self.coordinator.pool_id, self._value_path, 0
+            )
         except Exception as err:
             raise HomeAssistantError(f"Failed to turn off: {err}") from err

--- a/custom_components/aquarite/time.py
+++ b/custom_components/aquarite/time.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import datetime
 from dataclasses import dataclass
 
+from aioaquarite import AquariteError
+
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -84,7 +86,7 @@ class AquariteTime(AquariteEntity, TimeEntity):
                 self.entity_description.value_path,
                 seconds,
             )
-        except Exception as err:
+        except AquariteError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",

--- a/custom_components/aquarite/time.py
+++ b/custom_components/aquarite/time.py
@@ -21,24 +21,24 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Aquarite time entities."""
-    dataservice = entry.runtime_data.coordinator
-    pool_id, pool_name = dataservice.pool_id, entry.title
-
     entities: list[AquariteTimeEntity] = []
 
-    for name, translation_key, path in (
-        ("Filtration Interval 1 From", "filtration_interval_1_from", "filtration.interval1.from"),
-        ("Filtration Interval 1 To", "filtration_interval_1_to", "filtration.interval1.to"),
-        ("Filtration Interval 2 From", "filtration_interval_2_from", "filtration.interval2.from"),
-        ("Filtration Interval 2 To", "filtration_interval_2_to", "filtration.interval2.to"),
-        ("Filtration Interval 3 From", "filtration_interval_3_from", "filtration.interval3.from"),
-        ("Filtration Interval 3 To", "filtration_interval_3_to", "filtration.interval3.to"),
-    ):
-        entities.append(
-            AquariteTimeEntity(
-                dataservice, pool_id, pool_name, name, translation_key, path,
+    for dataservice in entry.runtime_data.coordinators.values():
+        pool_id, pool_name = dataservice.pool_id, dataservice.pool_name
+
+        for name, translation_key, path in (
+            ("Filtration Interval 1 From", "filtration_interval_1_from", "filtration.interval1.from"),
+            ("Filtration Interval 1 To", "filtration_interval_1_to", "filtration.interval1.to"),
+            ("Filtration Interval 2 From", "filtration_interval_2_from", "filtration.interval2.from"),
+            ("Filtration Interval 2 To", "filtration_interval_2_to", "filtration.interval2.to"),
+            ("Filtration Interval 3 From", "filtration_interval_3_from", "filtration.interval3.from"),
+            ("Filtration Interval 3 To", "filtration_interval_3_to", "filtration.interval3.to"),
+        ):
+            entities.append(
+                AquariteTimeEntity(
+                    dataservice, pool_id, pool_name, name, translation_key, path,
+                )
             )
-        )
 
     async_add_entities(entities)
 

--- a/custom_components/aquarite/time.py
+++ b/custom_components/aquarite/time.py
@@ -1,4 +1,5 @@
 """Aquarite Time entities for filtration interval control."""
+
 from __future__ import annotations
 
 import datetime

--- a/custom_components/aquarite/time.py
+++ b/custom_components/aquarite/time.py
@@ -10,6 +10,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AquariteConfigEntry
+from .const import DOMAIN
 from .coordinator import AquariteDataUpdateCoordinator
 from .entity import AquariteEntity
 
@@ -84,4 +85,8 @@ class AquariteTime(AquariteEntity, TimeEntity):
                 seconds,
             )
         except Exception as err:
-            raise HomeAssistantError(f"Failed to set time: {err}") from err
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/custom_components/aquarite/time.py
+++ b/custom_components/aquarite/time.py
@@ -24,8 +24,6 @@ async def async_setup_entry(
     entities: list[AquariteTimeEntity] = []
 
     for dataservice in entry.runtime_data.coordinators.values():
-        pool_id, pool_name = dataservice.pool_id, dataservice.pool_name
-
         for name, translation_key, path in (
             ("Filtration Interval 1 From", "filtration_interval_1_from", "filtration.interval1.from"),
             ("Filtration Interval 1 To", "filtration_interval_1_to", "filtration.interval1.to"),
@@ -36,7 +34,7 @@ async def async_setup_entry(
         ):
             entities.append(
                 AquariteTimeEntity(
-                    dataservice, pool_id, pool_name, name, translation_key, path,
+                    dataservice, name, translation_key, path,
                 )
             )
 
@@ -49,14 +47,12 @@ class AquariteTimeEntity(AquariteEntity, TimeEntity):
     def __init__(
         self,
         dataservice: AquariteDataUpdateCoordinator,
-        pool_id: str,
-        pool_name: str,
         name: str,
         translation_key: str,
         value_path: str,
     ) -> None:
         """Initialize the time entity."""
-        super().__init__(dataservice, pool_id, pool_name)
+        super().__init__(dataservice)
         self._value_path = value_path
         self._attr_translation_key = translation_key
         self._attr_unique_id = self.build_unique_id(name)
@@ -78,7 +74,7 @@ class AquariteTimeEntity(AquariteEntity, TimeEntity):
         seconds = value.hour * 3600 + value.minute * 60
         try:
             await self.coordinator.api.set_value(
-                self._pool_id, self._value_path, seconds,
+                self.coordinator.pool_id, self._value_path, seconds,
             )
         except Exception as err:
             raise HomeAssistantError(f"Failed to set time: {err}") from err

--- a/custom_components/aquarite/time.py
+++ b/custom_components/aquarite/time.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import AquariteConfigEntry
 from .const import DOMAIN
@@ -38,7 +38,7 @@ TIMES: tuple[AquariteTimeEntityDescription, ...] = tuple(
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Aquarite time entities."""
     async_add_entities(

--- a/custom_components/aquarite/time.py
+++ b/custom_components/aquarite/time.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import datetime
+from dataclasses import dataclass
 
-from homeassistant.components.time import TimeEntity
+from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -15,54 +16,58 @@ from .entity import AquariteEntity
 PARALLEL_UPDATES = 1
 
 
+@dataclass(frozen=True, kw_only=True)
+class AquariteTimeEntityDescription(TimeEntityDescription):
+    """Describes an Aquarite time entity."""
+
+    value_path: str
+
+
+TIMES: tuple[AquariteTimeEntityDescription, ...] = tuple(
+    AquariteTimeEntityDescription(
+        key=f"filtration_interval_{i}_{which}",
+        translation_key=f"filtration_interval_{i}_{which}",
+        value_path=f"filtration.interval{i}.{which}",
+    )
+    for i in range(1, 4)
+    for which in ("from", "to")
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: AquariteConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Aquarite time entities."""
-    entities: list[AquariteTimeEntity] = []
-
-    for dataservice in entry.runtime_data.coordinators.values():
-        for name, translation_key, path in (
-            ("Filtration Interval 1 From", "filtration_interval_1_from", "filtration.interval1.from"),
-            ("Filtration Interval 1 To", "filtration_interval_1_to", "filtration.interval1.to"),
-            ("Filtration Interval 2 From", "filtration_interval_2_from", "filtration.interval2.from"),
-            ("Filtration Interval 2 To", "filtration_interval_2_to", "filtration.interval2.to"),
-            ("Filtration Interval 3 From", "filtration_interval_3_from", "filtration.interval3.from"),
-            ("Filtration Interval 3 To", "filtration_interval_3_to", "filtration.interval3.to"),
-        ):
-            entities.append(
-                AquariteTimeEntity(
-                    dataservice, name, translation_key, path,
-                )
-            )
-
-    async_add_entities(entities)
+    async_add_entities(
+        AquariteTime(coordinator, description)
+        for coordinator in entry.runtime_data.coordinators.values()
+        for description in TIMES
+    )
 
 
-class AquariteTimeEntity(AquariteEntity, TimeEntity):
-    """Time entity for filtration interval from/to values."""
+class AquariteTime(AquariteEntity, TimeEntity):
+    """Aquarite time entity for filtration interval from/to values."""
+
+    entity_description: AquariteTimeEntityDescription
 
     def __init__(
         self,
-        dataservice: AquariteDataUpdateCoordinator,
-        name: str,
-        translation_key: str,
-        value_path: str,
+        coordinator: AquariteDataUpdateCoordinator,
+        description: AquariteTimeEntityDescription,
     ) -> None:
         """Initialize the time entity."""
-        super().__init__(dataservice)
-        self._value_path = value_path
-        self._attr_translation_key = translation_key
-        self._attr_unique_id = self.build_unique_id(name)
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = self.build_unique_id(description.key)
 
     @property
     def native_value(self) -> datetime.time | None:
         """Return the interval time as a time object."""
-        raw_value = self.coordinator.get_value(self._value_path)
+        raw = self.coordinator.get_value(self.entity_description.value_path)
         try:
-            seconds = int(raw_value)
+            seconds = int(raw)
             hours = (seconds // 3600) % 24
             minutes = (seconds % 3600) // 60
             return datetime.time(hours, minutes)
@@ -74,7 +79,9 @@ class AquariteTimeEntity(AquariteEntity, TimeEntity):
         seconds = value.hour * 3600 + value.minute * 60
         try:
             await self.coordinator.api.set_value(
-                self.coordinator.pool_id, self._value_path, seconds,
+                self.coordinator.pool_id,
+                self.entity_description.value_path,
+                seconds,
             )
         except Exception as err:
             raise HomeAssistantError(f"Failed to set time: {err}") from err

--- a/custom_components/aquarite/translations/da.json
+++ b/custom_components/aquarite/translations/da.json
@@ -1,128 +1,60 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "Kontoen er allerede konfigureret",
+      "reauth_successful": "Genautentificering lykkedes",
+      "reconfigure_successful": "Genkonfigurering lykkedes"
+    },
+    "error": {
+      "invalid_auth": "Ugyldig godkendelse",
+      "unknown": "Uventet fejl"
+    },
     "step": {
-      "user": {
-        "data": {
-          "username": "Hayward brugernavn",
-          "password": "Kodeord"
-        },
-        "description": "Udfyld dine Hayward loginoplysninger.",
-        "title": "Login"
-      },
       "reauth_confirm": {
         "data": {
-          "username": "Brugernavn",
-          "password": "Kodeord"
+          "password": "Kodeord",
+          "username": "Brugernavn"
+        },
+        "data_description": {
+          "password": "Kodeord til din Hayward-konto.",
+          "username": "E-mailadresse eller brugernavn registreret hos Hayward."
         },
         "description": "Genautentificer din Hayward-konto for at fortsætte.",
         "title": "Genautentificer"
       },
-      "pool": {
-        "data": {
-          "pool_id": "Pool"
-        },
-        "description": "Vælg pool der skal tilføjes HA.",
-        "title": "Vælg Pool"
-      },
       "reconfigure": {
         "data": {
-          "username": "Brugernavn",
-          "password": "Kodeord"
+          "password": "Kodeord",
+          "username": "Brugernavn"
+        },
+        "data_description": {
+          "password": "Kodeord til din Hayward-konto.",
+          "username": "E-mailadresse eller brugernavn registreret hos Hayward."
         },
         "description": "Opdater dine Hayward loginoplysninger.",
         "title": "Genkonfigurer"
-      }
-    },
-    "error": {
-      "auth_error": "Login fejlede, tjek brugernavn og kodeord.",
-      "no_pools_found": "Ingen pools fundet for din konto.",
-      "unknown_error": "Uventet fejl. Prøv igen."
-    },
-    "abort": {
-      "reauth_successful": "Genautentificering lykkedes.",
-      "reconfigure_successful": "Genkonfigurering lykkedes."
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
+      },
+      "user": {
         "data": {
-          "health_check_interval": "Sundhedstjek interval (sekunder)"
+          "password": "Kodeord",
+          "username": "Brugernavn"
         },
-        "description": "Konfigurer Aquarite integrationen.",
-        "title": "Indstillinger"
+        "data_description": {
+          "password": "Kodeord til din Hayward-konto.",
+          "username": "E-mailadresse eller brugernavn registreret hos Hayward."
+        },
+        "description": "Udfyld dine Hayward loginoplysninger. Alle pools tilknyttet kontoen opdages automatisk.",
+        "title": "Login"
       }
     }
   },
   "entity": {
-    "sensor": {
-      "temperature": {
-        "name": "Temperatur"
-      },
-      "cd": {
-        "name": "CD"
-      },
-      "cl": {
-        "name": "CL"
-      },
-      "ph": {
-        "name": "pH"
-      },
-      "rx": {
-        "name": "Rx"
-      },
-      "uv": {
-        "name": "UV"
-      },
-      "electrolysis": {
-        "name": "Elektrolyse"
-      },
-      "hydrolysis": {
-        "name": "Hydrolyse"
-      },
-      "filtration_intel_time": {
-        "name": "Filtrering intel tid"
-      },
-      "city": {
-        "name": "By"
-      },
-      "street": {
-        "name": "Gade"
-      },
-      "zipcode": {
-        "name": "Postnummer"
-      },
-      "country": {
-        "name": "Land"
-      },
-      "latitude": {
-        "name": "Breddegrad"
-      },
-      "longitude": {
-        "name": "Længdegrad"
-      },
-      "pool_name": {
-        "name": "Poolnavn"
-      },
-      "rssi": {
-        "name": "Wi-Fi signalstyrke"
-      }
-    },
     "binary_sensor": {
-      "hidro_flow_status": {
-        "name": "Hydrolyse flow status"
-      },
-      "filtration_status": {
-        "name": "Filtreringsstatus"
+      "acid_tank": {
+        "name": "Syretank"
       },
       "backwash_status": {
-        "name": "Tilbageskylningsstatus"
-      },
-      "hidro_cover_reduction": {
-        "name": "Hydrolyse overdækning reduktion"
-      },
-      "ph_pump_alarm": {
-        "name": "pH pumpe alarm"
+        "name": "Tilbageskyl status"
       },
       "cd_module_installed": {
         "name": "CD modul installeret"
@@ -130,17 +62,38 @@
       "cl_module_installed": {
         "name": "CL modul installeret"
       },
-      "rx_module_installed": {
-        "name": "RX modul installeret"
+      "cl_pump_status": {
+        "name": "Klorpumpe status"
       },
-      "ph_module_installed": {
-        "name": "pH modul installeret"
+      "connected": {
+        "name": "Forbundet"
       },
-      "io_module_installed": {
-        "name": "IO modul installeret"
+      "electrolysis_low": {
+        "name": "Elektrolyse lav"
+      },
+      "filtration_status": {
+        "name": "Filtreringsstatus"
+      },
+      "heating_status": {
+        "name": "Opvarmningsstatus"
+      },
+      "hidro_cover_reduction": {
+        "name": "Hydrolyse afdækning reduktion"
+      },
+      "hidro_fl2_status": {
+        "name": "Hydrolyse FL2 status"
+      },
+      "hidro_flow_status": {
+        "name": "Hydrolyse flow status"
       },
       "hidro_module_installed": {
         "name": "Hydrolyse modul installeret"
+      },
+      "hydrolysis_low": {
+        "name": "Hydrolyse lav"
+      },
+      "io_module_installed": {
+        "name": "IO modul installeret"
       },
       "ph_acid_pump": {
         "name": "pH syrepumpe"
@@ -148,37 +101,151 @@
       "ph_base_pump": {
         "name": "pH basepumpe"
       },
-      "cl_pump_status": {
-        "name": "Klorpumpestatus"
+      "ph_module_installed": {
+        "name": "pH modul installeret"
+      },
+      "ph_pump_alarm": {
+        "name": "pH pumpealarm"
+      },
+      "rx_module_installed": {
+        "name": "RX modul installeret"
       },
       "rx_pump_status": {
         "name": "Rx pumpestatus"
+      }
+    },
+    "button": {
+      "led_pulse": {
+        "name": "LED puls"
+      }
+    },
+    "device_tracker": {
+      "location": {
+        "name": "Placering"
+      }
+    },
+    "light": {
+      "pool_light": {
+        "name": "Lys"
+      }
+    },
+    "number": {
+      "electrolysis_setpoint": {
+        "name": "Elektrolyse setpunkt"
       },
-      "heating_status": {
-        "name": "Opvarmningsstatus"
+      "heating_mode_max_temperature": {
+        "name": "Opvarmning max temperatur"
       },
-      "connected": {
-        "name": "Forbundet"
+      "heating_mode_min_temperature": {
+        "name": "Opvarmning min temperatur"
       },
-      "hidro_fl2_status": {
-        "name": "Hydrolyse FL2 status"
+      "intel_mode_temperature": {
+        "name": "Intel tilstand temperatur"
       },
-      "acid_tank": {
-        "name": "Syretank"
+      "ph_low": {
+        "name": "pH lav"
       },
-      "electrolysis_low": {
-        "name": "Elektrolyse lav"
+      "ph_max": {
+        "name": "pH max"
       },
-      "hydrolysis_low": {
-        "name": "Hydrolyse lav"
+      "redox_setpoint": {
+        "name": "Redox setpunkt"
+      },
+      "smart_mode_max_temperature": {
+        "name": "Smart max temperatur"
+      },
+      "smart_mode_min_temperature": {
+        "name": "Smart min temperatur"
+      }
+    },
+    "select": {
+      "filtration_timer_speed_1": {
+        "name": "Filtrering timer hastighed 1",
+        "state": {
+          "high": "Høj",
+          "medium": "Middel",
+          "slow": "Langsom"
+        }
+      },
+      "filtration_timer_speed_2": {
+        "name": "Filtrering timer hastighed 2",
+        "state": {
+          "high": "Høj",
+          "medium": "Middel",
+          "slow": "Langsom"
+        }
+      },
+      "filtration_timer_speed_3": {
+        "name": "Filtrering timer hastighed 3",
+        "state": {
+          "high": "Høj",
+          "medium": "Middel",
+          "slow": "Langsom"
+        }
+      },
+      "pump_mode": {
+        "name": "Pumpetilstand",
+        "state": {
+          "auto": "Auto",
+          "heat": "Opvarmning",
+          "intel": "Intel",
+          "manual": "Manuel",
+          "smart": "Smart"
+        }
+      },
+      "pump_speed": {
+        "name": "Pumpehastighed",
+        "state": {
+          "high": "Høj",
+          "medium": "Middel",
+          "slow": "Langsom"
+        }
+      }
+    },
+    "sensor": {
+      "cd": {
+        "name": "CD"
+      },
+      "cl": {
+        "name": "CL"
+      },
+      "electrolysis": {
+        "name": "Elektrolyse"
+      },
+      "filtration_intel_time": {
+        "name": "Filtrering intel tid"
+      },
+      "hydrolysis": {
+        "name": "Hydrolyse"
+      },
+      "ph": {
+        "name": "pH"
+      },
+      "rssi": {
+        "name": "Wi-Fi signalstyrke"
+      },
+      "rx": {
+        "name": "Rx"
+      },
+      "temperature": {
+        "name": "Temperatur"
+      },
+      "uv": {
+        "name": "UV"
       }
     },
     "switch": {
-      "electrolysis_cover": {
-        "name": "Elektrolyse overdækning"
-      },
       "electrolysis_boost": {
         "name": "Elektrolyse boost"
+      },
+      "electrolysis_cover": {
+        "name": "Elektrolyse afdækning"
+      },
+      "filtration": {
+        "name": "Filtrering"
+      },
+      "heating_climate": {
+        "name": "Opvarmning klima"
       },
       "relay_1": {
         "name": "Relæ 1"
@@ -192,87 +259,8 @@
       "relay_4": {
         "name": "Relæ 4"
       },
-      "filtration": {
-        "name": "Filtrering"
-      },
-      "heating_climate": {
-        "name": "Opvarmning klima"
-      },
       "smart_mode_freeze": {
         "name": "Smart frostbeskyttelse"
-      }
-    },
-    "number": {
-      "redox_setpoint": {
-        "name": "Redox sætpunkt"
-      },
-      "ph_low": {
-        "name": "pH lav"
-      },
-      "ph_max": {
-        "name": "pH maks"
-      },
-      "electrolysis_setpoint": {
-        "name": "Elektrolyse sætpunkt"
-      },
-      "intel_mode_temperature": {
-        "name": "Intel tilstand temperatur"
-      },
-      "heating_mode_min_temperature": {
-        "name": "Opvarmning min temperatur"
-      },
-      "heating_mode_max_temperature": {
-        "name": "Opvarmning maks temperatur"
-      },
-      "smart_mode_min_temperature": {
-        "name": "Smart min temperatur"
-      },
-      "smart_mode_max_temperature": {
-        "name": "Smart maks temperatur"
-      }
-    },
-    "select": {
-      "pump_mode": {
-        "name": "Pumpetilstand",
-        "state": {
-          "manual": "Manuel",
-          "auto": "Automatisk",
-          "heat": "Opvarmning",
-          "smart": "Smart",
-          "intel": "Intel"
-        }
-      },
-      "pump_speed": {
-        "name": "Pumpehastighed",
-        "state": {
-          "slow": "Langsom",
-          "medium": "Middel",
-          "high": "Høj"
-        }
-      },
-      "filtration_timer_speed_1": {
-        "name": "Filtrering timer hastighed 1",
-        "state": {
-          "slow": "Langsom",
-          "medium": "Middel",
-          "high": "Høj"
-        }
-      },
-      "filtration_timer_speed_2": {
-        "name": "Filtrering timer hastighed 2",
-        "state": {
-          "slow": "Langsom",
-          "medium": "Middel",
-          "high": "Høj"
-        }
-      },
-      "filtration_timer_speed_3": {
-        "name": "Filtrering timer hastighed 3",
-        "state": {
-          "slow": "Langsom",
-          "medium": "Middel",
-          "high": "Høj"
-        }
       }
     },
     "time": {
@@ -294,35 +282,20 @@
       "filtration_interval_3_to": {
         "name": "Filtrering interval 3 til"
       }
-    },
-    "light": {
-      "pool_light": {
-        "name": "Lys"
-      }
-    },
-    "button": {
-      "led_pulse": {
-        "name": "LED puls"
-      }
-    },
-    "device_tracker": {
-      "location": {
-        "name": "Placering"
-      }
     }
   },
   "exceptions": {
-    "communication_error": {
-      "message": "Der opstod en fejl under kommunikation med Aquarite-enheden: {error}"
-    },
     "authentication_error": {
-      "message": "Godkendelse mislykkedes. Tjek dine loginoplysninger."
+      "message": "Godkendelse fejlede. Tjek dine loginoplysninger."
+    },
+    "communication_error": {
+      "message": "Fejl ved kommunikation med Aquarite-enheden: {error}"
     }
   },
   "services": {
     "sync_pool_time": {
-      "name": "Synkroniser pooltid",
-      "description": "Synkroniser Home Assistant dato og tid til poolcontrolleren."
+      "description": "Synkroniserer Home Assistant dato og tid til pool-controlleren.",
+      "name": "Synkroniser pooltid"
     }
   }
 }

--- a/custom_components/aquarite/translations/en.json
+++ b/custom_components/aquarite/translations/en.json
@@ -1,128 +1,60 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "Account is already configured",
+      "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Reconfiguration was successful"
+    },
+    "error": {
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
     "step": {
-      "user": {
-        "data": {
-          "username": "Hayward Username",
-          "password": "Password"
-        },
-        "description": "Enter your Hayward credentials.",
-        "title": "Authentication"
-      },
       "reauth_confirm": {
         "data": {
-          "username": "Username",
-          "password": "Password"
+          "password": "Password",
+          "username": "Username"
+        },
+        "data_description": {
+          "password": "Password for your Hayward account.",
+          "username": "Email address or username registered with Hayward."
         },
         "description": "Re-authenticate your Hayward account to continue.",
         "title": "Reauthenticate"
       },
-      "pool": {
-        "data": {
-          "pool_id": "Pool"
-        },
-        "description": "Please choose the pool for this integration.",
-        "title": "Select Pool"
-      },
       "reconfigure": {
         "data": {
-          "username": "Username",
-          "password": "Password"
+          "password": "Password",
+          "username": "Username"
+        },
+        "data_description": {
+          "password": "Password for your Hayward account.",
+          "username": "Email address or username registered with Hayward."
         },
         "description": "Update your Hayward credentials.",
         "title": "Reconfigure"
-      }
-    },
-    "error": {
-      "auth_error": "Authorization failed, check username and password.",
-      "no_pools_found": "No pools found for your account.",
-      "unknown_error": "Unexpected error. Please try again."
-    },
-    "abort": {
-      "reauth_successful": "Re-authentication was successful.",
-      "reconfigure_successful": "Reconfiguration was successful."
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
+      },
+      "user": {
         "data": {
-          "health_check_interval": "Health check interval (seconds)"
+          "password": "Password",
+          "username": "Username"
         },
-        "description": "Configure the Aquarite integration.",
-        "title": "Options"
+        "data_description": {
+          "password": "Password for your Hayward account.",
+          "username": "Email address or username registered with Hayward."
+        },
+        "description": "Enter your Hayward credentials. All pools linked to the account will be discovered automatically.",
+        "title": "Authentication"
       }
     }
   },
   "entity": {
-    "sensor": {
-      "temperature": {
-        "name": "Temperature"
-      },
-      "cd": {
-        "name": "CD"
-      },
-      "cl": {
-        "name": "CL"
-      },
-      "ph": {
-        "name": "pH"
-      },
-      "rx": {
-        "name": "Rx"
-      },
-      "uv": {
-        "name": "UV"
-      },
-      "electrolysis": {
-        "name": "Electrolysis"
-      },
-      "hydrolysis": {
-        "name": "Hydrolysis"
-      },
-      "filtration_intel_time": {
-        "name": "Filtration intel time"
-      },
-      "city": {
-        "name": "City"
-      },
-      "street": {
-        "name": "Street"
-      },
-      "zipcode": {
-        "name": "Zipcode"
-      },
-      "country": {
-        "name": "Country"
-      },
-      "latitude": {
-        "name": "Latitude"
-      },
-      "longitude": {
-        "name": "Longitude"
-      },
-      "pool_name": {
-        "name": "Pool name"
-      },
-      "rssi": {
-        "name": "Wi-Fi signal strength"
-      }
-    },
     "binary_sensor": {
-      "hidro_flow_status": {
-        "name": "Hydrolysis flow status"
-      },
-      "filtration_status": {
-        "name": "Filtration status"
+      "acid_tank": {
+        "name": "Acid tank"
       },
       "backwash_status": {
         "name": "Backwash status"
-      },
-      "hidro_cover_reduction": {
-        "name": "Hydrolysis cover reduction"
-      },
-      "ph_pump_alarm": {
-        "name": "pH pump alarm"
       },
       "cd_module_installed": {
         "name": "CD module installed"
@@ -130,17 +62,38 @@
       "cl_module_installed": {
         "name": "CL module installed"
       },
-      "rx_module_installed": {
-        "name": "RX module installed"
+      "cl_pump_status": {
+        "name": "Chlorine pump status"
       },
-      "ph_module_installed": {
-        "name": "pH module installed"
+      "connected": {
+        "name": "Connected"
       },
-      "io_module_installed": {
-        "name": "IO module installed"
+      "electrolysis_low": {
+        "name": "Electrolysis low"
+      },
+      "filtration_status": {
+        "name": "Filtration status"
+      },
+      "heating_status": {
+        "name": "Heating status"
+      },
+      "hidro_cover_reduction": {
+        "name": "Hydrolysis cover reduction"
+      },
+      "hidro_fl2_status": {
+        "name": "Hydrolysis FL2 status"
+      },
+      "hidro_flow_status": {
+        "name": "Hydrolysis flow status"
       },
       "hidro_module_installed": {
         "name": "Hydrolysis module installed"
+      },
+      "hydrolysis_low": {
+        "name": "Hydrolysis low"
+      },
+      "io_module_installed": {
+        "name": "IO module installed"
       },
       "ph_acid_pump": {
         "name": "pH acid pump"
@@ -148,37 +101,151 @@
       "ph_base_pump": {
         "name": "pH base pump"
       },
-      "cl_pump_status": {
-        "name": "Chlorine pump status"
+      "ph_module_installed": {
+        "name": "pH module installed"
+      },
+      "ph_pump_alarm": {
+        "name": "pH pump alarm"
+      },
+      "rx_module_installed": {
+        "name": "RX module installed"
       },
       "rx_pump_status": {
         "name": "Rx pump status"
+      }
+    },
+    "button": {
+      "led_pulse": {
+        "name": "LED pulse"
+      }
+    },
+    "device_tracker": {
+      "location": {
+        "name": "Location"
+      }
+    },
+    "light": {
+      "pool_light": {
+        "name": "Light"
+      }
+    },
+    "number": {
+      "electrolysis_setpoint": {
+        "name": "Electrolysis setpoint"
       },
-      "heating_status": {
-        "name": "Heating status"
+      "heating_mode_max_temperature": {
+        "name": "Heating mode max temperature"
       },
-      "connected": {
-        "name": "Connected"
+      "heating_mode_min_temperature": {
+        "name": "Heating mode min temperature"
       },
-      "hidro_fl2_status": {
-        "name": "Hydrolysis FL2 status"
+      "intel_mode_temperature": {
+        "name": "Intel mode temperature"
       },
-      "acid_tank": {
-        "name": "Acid tank"
+      "ph_low": {
+        "name": "pH low"
       },
-      "electrolysis_low": {
-        "name": "Electrolysis low"
+      "ph_max": {
+        "name": "pH max"
       },
-      "hydrolysis_low": {
-        "name": "Hydrolysis low"
+      "redox_setpoint": {
+        "name": "Redox setpoint"
+      },
+      "smart_mode_max_temperature": {
+        "name": "Smart mode max temperature"
+      },
+      "smart_mode_min_temperature": {
+        "name": "Smart mode min temperature"
+      }
+    },
+    "select": {
+      "filtration_timer_speed_1": {
+        "name": "Filtration timer speed 1",
+        "state": {
+          "high": "High",
+          "medium": "Medium",
+          "slow": "Slow"
+        }
+      },
+      "filtration_timer_speed_2": {
+        "name": "Filtration timer speed 2",
+        "state": {
+          "high": "High",
+          "medium": "Medium",
+          "slow": "Slow"
+        }
+      },
+      "filtration_timer_speed_3": {
+        "name": "Filtration timer speed 3",
+        "state": {
+          "high": "High",
+          "medium": "Medium",
+          "slow": "Slow"
+        }
+      },
+      "pump_mode": {
+        "name": "Pump mode",
+        "state": {
+          "auto": "Auto",
+          "heat": "Heat",
+          "intel": "Intel",
+          "manual": "Manual",
+          "smart": "Smart"
+        }
+      },
+      "pump_speed": {
+        "name": "Pump speed",
+        "state": {
+          "high": "High",
+          "medium": "Medium",
+          "slow": "Slow"
+        }
+      }
+    },
+    "sensor": {
+      "cd": {
+        "name": "CD"
+      },
+      "cl": {
+        "name": "CL"
+      },
+      "electrolysis": {
+        "name": "Electrolysis"
+      },
+      "filtration_intel_time": {
+        "name": "Filtration intel time"
+      },
+      "hydrolysis": {
+        "name": "Hydrolysis"
+      },
+      "ph": {
+        "name": "pH"
+      },
+      "rssi": {
+        "name": "Wi-Fi signal strength"
+      },
+      "rx": {
+        "name": "Rx"
+      },
+      "temperature": {
+        "name": "Temperature"
+      },
+      "uv": {
+        "name": "UV"
       }
     },
     "switch": {
+      "electrolysis_boost": {
+        "name": "Electrolysis boost"
+      },
       "electrolysis_cover": {
         "name": "Electrolysis cover"
       },
-      "electrolysis_boost": {
-        "name": "Electrolysis boost"
+      "filtration": {
+        "name": "Filtration"
+      },
+      "heating_climate": {
+        "name": "Heating climate"
       },
       "relay_1": {
         "name": "Relay 1"
@@ -192,87 +259,8 @@
       "relay_4": {
         "name": "Relay 4"
       },
-      "filtration": {
-        "name": "Filtration"
-      },
-      "heating_climate": {
-        "name": "Heating climate"
-      },
       "smart_mode_freeze": {
         "name": "Smart mode freeze protection"
-      }
-    },
-    "number": {
-      "redox_setpoint": {
-        "name": "Redox setpoint"
-      },
-      "ph_low": {
-        "name": "pH low"
-      },
-      "ph_max": {
-        "name": "pH max"
-      },
-      "electrolysis_setpoint": {
-        "name": "Electrolysis setpoint"
-      },
-      "intel_mode_temperature": {
-        "name": "Intel mode temperature"
-      },
-      "heating_mode_min_temperature": {
-        "name": "Heating mode min temperature"
-      },
-      "heating_mode_max_temperature": {
-        "name": "Heating mode max temperature"
-      },
-      "smart_mode_min_temperature": {
-        "name": "Smart mode min temperature"
-      },
-      "smart_mode_max_temperature": {
-        "name": "Smart mode max temperature"
-      }
-    },
-    "select": {
-      "pump_mode": {
-        "name": "Pump mode",
-        "state": {
-          "manual": "Manual",
-          "auto": "Auto",
-          "heat": "Heat",
-          "smart": "Smart",
-          "intel": "Intel"
-        }
-      },
-      "pump_speed": {
-        "name": "Pump speed",
-        "state": {
-          "slow": "Slow",
-          "medium": "Medium",
-          "high": "High"
-        }
-      },
-      "filtration_timer_speed_1": {
-        "name": "Filtration timer speed 1",
-        "state": {
-          "slow": "Slow",
-          "medium": "Medium",
-          "high": "High"
-        }
-      },
-      "filtration_timer_speed_2": {
-        "name": "Filtration timer speed 2",
-        "state": {
-          "slow": "Slow",
-          "medium": "Medium",
-          "high": "High"
-        }
-      },
-      "filtration_timer_speed_3": {
-        "name": "Filtration timer speed 3",
-        "state": {
-          "slow": "Slow",
-          "medium": "Medium",
-          "high": "High"
-        }
       }
     },
     "time": {
@@ -294,35 +282,20 @@
       "filtration_interval_3_to": {
         "name": "Filtration interval 3 to"
       }
-    },
-    "light": {
-      "pool_light": {
-        "name": "Light"
-      }
-    },
-    "button": {
-      "led_pulse": {
-        "name": "LED pulse"
-      }
-    },
-    "device_tracker": {
-      "location": {
-        "name": "Location"
-      }
     }
   },
   "exceptions": {
-    "communication_error": {
-      "message": "An error occurred while communicating with the Aquarite device: {error}"
-    },
     "authentication_error": {
       "message": "Authentication failed. Please check your credentials."
+    },
+    "communication_error": {
+      "message": "Error communicating with the Aquarite device: {error}"
     }
   },
   "services": {
     "sync_pool_time": {
-      "name": "Sync pool time",
-      "description": "Sync the Home Assistant date and time to the pool controller."
+      "description": "Syncs the Home Assistant date and time to the pool controller.",
+      "name": "Sync pool time"
     }
   }
 }

--- a/custom_components/aquarite/translations/nl.json
+++ b/custom_components/aquarite/translations/nl.json
@@ -1,128 +1,60 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "Account is al geconfigureerd",
+      "reauth_successful": "Herauthenticatie is geslaagd",
+      "reconfigure_successful": "Herconfiguratie is geslaagd"
+    },
+    "error": {
+      "invalid_auth": "Ongeldige authenticatie",
+      "unknown": "Onverwachte fout"
+    },
     "step": {
-      "user": {
-        "data": {
-          "username": "Hayward-gebruikersnaam",
-          "password": "Wachtwoord"
-        },
-        "description": "Vul je Hayward-inloggegevens in.",
-        "title": "Authenticatie"
-      },
       "reauth_confirm": {
         "data": {
-          "username": "Gebruikersnaam",
-          "password": "Wachtwoord"
+          "password": "Wachtwoord",
+          "username": "Gebruikersnaam"
+        },
+        "data_description": {
+          "password": "Wachtwoord voor je Hayward-account.",
+          "username": "E-mailadres of gebruikersnaam geregistreerd bij Hayward."
         },
         "description": "Authenticeer je Hayward-account opnieuw om verder te gaan.",
         "title": "Herauthenticatie"
       },
-      "pool": {
-        "data": {
-          "pool_id": "Zwembad"
-        },
-        "description": "Selecteer het zwembad voor deze integratie.",
-        "title": "Selecteer Zwembad"
-      },
       "reconfigure": {
         "data": {
-          "username": "Gebruikersnaam",
-          "password": "Wachtwoord"
+          "password": "Wachtwoord",
+          "username": "Gebruikersnaam"
+        },
+        "data_description": {
+          "password": "Wachtwoord voor je Hayward-account.",
+          "username": "E-mailadres of gebruikersnaam geregistreerd bij Hayward."
         },
         "description": "Werk je Hayward-inloggegevens bij.",
         "title": "Herconfigureren"
-      }
-    },
-    "error": {
-      "auth_error": "Autorisatie mislukt, controleer gebruikersnaam en wachtwoord.",
-      "no_pools_found": "Geen zwembaden gevonden voor je account.",
-      "unknown_error": "Onverwachte fout. Probeer het opnieuw."
-    },
-    "abort": {
-      "reauth_successful": "Herauthenticatie is geslaagd.",
-      "reconfigure_successful": "Herconfiguratie is geslaagd."
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
+      },
+      "user": {
         "data": {
-          "health_check_interval": "Gezondheidscontrole-interval (seconden)"
+          "password": "Wachtwoord",
+          "username": "Gebruikersnaam"
         },
-        "description": "Configureer de Aquarite integratie.",
-        "title": "Opties"
+        "data_description": {
+          "password": "Wachtwoord voor je Hayward-account.",
+          "username": "E-mailadres of gebruikersnaam geregistreerd bij Hayward."
+        },
+        "description": "Vul je Hayward-inloggegevens in. Alle zwembaden gekoppeld aan het account worden automatisch ontdekt.",
+        "title": "Authenticatie"
       }
     }
   },
   "entity": {
-    "sensor": {
-      "temperature": {
-        "name": "Temperatuur"
-      },
-      "cd": {
-        "name": "CD"
-      },
-      "cl": {
-        "name": "CL"
-      },
-      "ph": {
-        "name": "pH"
-      },
-      "rx": {
-        "name": "Rx"
-      },
-      "uv": {
-        "name": "UV"
-      },
-      "electrolysis": {
-        "name": "Elektrolyse"
-      },
-      "hydrolysis": {
-        "name": "Hydrolyse"
-      },
-      "filtration_intel_time": {
-        "name": "Filtratie intel tijd"
-      },
-      "city": {
-        "name": "Stad"
-      },
-      "street": {
-        "name": "Straat"
-      },
-      "zipcode": {
-        "name": "Postcode"
-      },
-      "country": {
-        "name": "Land"
-      },
-      "latitude": {
-        "name": "Breedtegraad"
-      },
-      "longitude": {
-        "name": "Lengtegraad"
-      },
-      "pool_name": {
-        "name": "Zwembadnaam"
-      },
-      "rssi": {
-        "name": "Wi-Fi signaalsterkte"
-      }
-    },
     "binary_sensor": {
-      "hidro_flow_status": {
-        "name": "Hydrolyse stroomstatus"
-      },
-      "filtration_status": {
-        "name": "Filtratiestatus"
+      "acid_tank": {
+        "name": "Zuurtank"
       },
       "backwash_status": {
         "name": "Terugspoelstatus"
-      },
-      "hidro_cover_reduction": {
-        "name": "Hydrolyse afdekking reductie"
-      },
-      "ph_pump_alarm": {
-        "name": "pH pomp alarm"
       },
       "cd_module_installed": {
         "name": "CD module geïnstalleerd"
@@ -130,17 +62,38 @@
       "cl_module_installed": {
         "name": "CL module geïnstalleerd"
       },
-      "rx_module_installed": {
-        "name": "RX module geïnstalleerd"
+      "cl_pump_status": {
+        "name": "Chloorpomp status"
       },
-      "ph_module_installed": {
-        "name": "pH module geïnstalleerd"
+      "connected": {
+        "name": "Verbonden"
       },
-      "io_module_installed": {
-        "name": "IO module geïnstalleerd"
+      "electrolysis_low": {
+        "name": "Elektrolyse laag"
+      },
+      "filtration_status": {
+        "name": "Filtratiestatus"
+      },
+      "heating_status": {
+        "name": "Verwarmingsstatus"
+      },
+      "hidro_cover_reduction": {
+        "name": "Hydrolyse afdekking reductie"
+      },
+      "hidro_fl2_status": {
+        "name": "Hydrolyse FL2 status"
+      },
+      "hidro_flow_status": {
+        "name": "Hydrolyse stroomstatus"
       },
       "hidro_module_installed": {
         "name": "Hydrolyse module geïnstalleerd"
+      },
+      "hydrolysis_low": {
+        "name": "Hydrolyse laag"
+      },
+      "io_module_installed": {
+        "name": "IO module geïnstalleerd"
       },
       "ph_acid_pump": {
         "name": "pH zuurpomp"
@@ -148,37 +101,151 @@
       "ph_base_pump": {
         "name": "pH basepomp"
       },
-      "cl_pump_status": {
-        "name": "Chloorpomp status"
+      "ph_module_installed": {
+        "name": "pH module geïnstalleerd"
+      },
+      "ph_pump_alarm": {
+        "name": "pH pomp alarm"
+      },
+      "rx_module_installed": {
+        "name": "RX module geïnstalleerd"
       },
       "rx_pump_status": {
         "name": "Rx pomp status"
+      }
+    },
+    "button": {
+      "led_pulse": {
+        "name": "LED puls"
+      }
+    },
+    "device_tracker": {
+      "location": {
+        "name": "Locatie"
+      }
+    },
+    "light": {
+      "pool_light": {
+        "name": "Licht"
+      }
+    },
+    "number": {
+      "electrolysis_setpoint": {
+        "name": "Elektrolyse instelpunt"
       },
-      "heating_status": {
-        "name": "Verwarmingsstatus"
+      "heating_mode_max_temperature": {
+        "name": "Verwarming max temperatuur"
       },
-      "connected": {
-        "name": "Verbonden"
+      "heating_mode_min_temperature": {
+        "name": "Verwarming min temperatuur"
       },
-      "hidro_fl2_status": {
-        "name": "Hydrolyse FL2 status"
+      "intel_mode_temperature": {
+        "name": "Intel modus temperatuur"
       },
-      "acid_tank": {
-        "name": "Zuurtank"
+      "ph_low": {
+        "name": "pH laag"
       },
-      "electrolysis_low": {
-        "name": "Elektrolyse laag"
+      "ph_max": {
+        "name": "pH max"
       },
-      "hydrolysis_low": {
-        "name": "Hydrolyse laag"
+      "redox_setpoint": {
+        "name": "Redox instelpunt"
+      },
+      "smart_mode_max_temperature": {
+        "name": "Smart max temperatuur"
+      },
+      "smart_mode_min_temperature": {
+        "name": "Smart min temperatuur"
+      }
+    },
+    "select": {
+      "filtration_timer_speed_1": {
+        "name": "Filtratie timer snelheid 1",
+        "state": {
+          "high": "Hoog",
+          "medium": "Gemiddeld",
+          "slow": "Langzaam"
+        }
+      },
+      "filtration_timer_speed_2": {
+        "name": "Filtratie timer snelheid 2",
+        "state": {
+          "high": "Hoog",
+          "medium": "Gemiddeld",
+          "slow": "Langzaam"
+        }
+      },
+      "filtration_timer_speed_3": {
+        "name": "Filtratie timer snelheid 3",
+        "state": {
+          "high": "Hoog",
+          "medium": "Gemiddeld",
+          "slow": "Langzaam"
+        }
+      },
+      "pump_mode": {
+        "name": "Pompmodus",
+        "state": {
+          "auto": "Automatisch",
+          "heat": "Verwarming",
+          "intel": "Intel",
+          "manual": "Handmatig",
+          "smart": "Smart"
+        }
+      },
+      "pump_speed": {
+        "name": "Pompsnelheid",
+        "state": {
+          "high": "Hoog",
+          "medium": "Gemiddeld",
+          "slow": "Langzaam"
+        }
+      }
+    },
+    "sensor": {
+      "cd": {
+        "name": "CD"
+      },
+      "cl": {
+        "name": "CL"
+      },
+      "electrolysis": {
+        "name": "Elektrolyse"
+      },
+      "filtration_intel_time": {
+        "name": "Filtratie intel tijd"
+      },
+      "hydrolysis": {
+        "name": "Hydrolyse"
+      },
+      "ph": {
+        "name": "pH"
+      },
+      "rssi": {
+        "name": "Wi-Fi signaalsterkte"
+      },
+      "rx": {
+        "name": "Rx"
+      },
+      "temperature": {
+        "name": "Temperatuur"
+      },
+      "uv": {
+        "name": "UV"
       }
     },
     "switch": {
+      "electrolysis_boost": {
+        "name": "Elektrolyse boost"
+      },
       "electrolysis_cover": {
         "name": "Elektrolyse afdekking"
       },
-      "electrolysis_boost": {
-        "name": "Elektrolyse boost"
+      "filtration": {
+        "name": "Filtratie"
+      },
+      "heating_climate": {
+        "name": "Verwarming klimaat"
       },
       "relay_1": {
         "name": "Relais 1"
@@ -192,87 +259,8 @@
       "relay_4": {
         "name": "Relais 4"
       },
-      "filtration": {
-        "name": "Filtratie"
-      },
-      "heating_climate": {
-        "name": "Verwarming klimaat"
-      },
       "smart_mode_freeze": {
         "name": "Smart vorstbescherming"
-      }
-    },
-    "number": {
-      "redox_setpoint": {
-        "name": "Redox instelpunt"
-      },
-      "ph_low": {
-        "name": "pH laag"
-      },
-      "ph_max": {
-        "name": "pH max"
-      },
-      "electrolysis_setpoint": {
-        "name": "Elektrolyse instelpunt"
-      },
-      "intel_mode_temperature": {
-        "name": "Intel modus temperatuur"
-      },
-      "heating_mode_min_temperature": {
-        "name": "Verwarming min temperatuur"
-      },
-      "heating_mode_max_temperature": {
-        "name": "Verwarming max temperatuur"
-      },
-      "smart_mode_min_temperature": {
-        "name": "Smart min temperatuur"
-      },
-      "smart_mode_max_temperature": {
-        "name": "Smart max temperatuur"
-      }
-    },
-    "select": {
-      "pump_mode": {
-        "name": "Pompmodus",
-        "state": {
-          "manual": "Handmatig",
-          "auto": "Automatisch",
-          "heat": "Verwarming",
-          "smart": "Smart",
-          "intel": "Intel"
-        }
-      },
-      "pump_speed": {
-        "name": "Pompsnelheid",
-        "state": {
-          "slow": "Langzaam",
-          "medium": "Gemiddeld",
-          "high": "Hoog"
-        }
-      },
-      "filtration_timer_speed_1": {
-        "name": "Filtratie timer snelheid 1",
-        "state": {
-          "slow": "Langzaam",
-          "medium": "Gemiddeld",
-          "high": "Hoog"
-        }
-      },
-      "filtration_timer_speed_2": {
-        "name": "Filtratie timer snelheid 2",
-        "state": {
-          "slow": "Langzaam",
-          "medium": "Gemiddeld",
-          "high": "Hoog"
-        }
-      },
-      "filtration_timer_speed_3": {
-        "name": "Filtratie timer snelheid 3",
-        "state": {
-          "slow": "Langzaam",
-          "medium": "Gemiddeld",
-          "high": "Hoog"
-        }
       }
     },
     "time": {
@@ -294,35 +282,20 @@
       "filtration_interval_3_to": {
         "name": "Filtratie interval 3 tot"
       }
-    },
-    "light": {
-      "pool_light": {
-        "name": "Licht"
-      }
-    },
-    "button": {
-      "led_pulse": {
-        "name": "LED puls"
-      }
-    },
-    "device_tracker": {
-      "location": {
-        "name": "Locatie"
-      }
     }
   },
   "exceptions": {
-    "communication_error": {
-      "message": "Er is een fout opgetreden bij de communicatie met het Aquarite-apparaat: {error}"
-    },
     "authentication_error": {
       "message": "Authenticatie mislukt. Controleer je inloggegevens."
+    },
+    "communication_error": {
+      "message": "Fout bij communicatie met het Aquarite-apparaat: {error}"
     }
   },
   "services": {
     "sync_pool_time": {
-      "name": "Zwembadtijd synchroniseren",
-      "description": "Synchroniseer de Home Assistant datum en tijd naar de zwembadcontroller."
+      "description": "Synchroniseert de Home Assistant datum en tijd naar de zwembadcontroller.",
+      "name": "Zwembadtijd synchroniseren"
     }
   }
 }


### PR DESCRIPTION
## Summary

Brings the custom component in line with the patterns accepted in the Aquarite HA core PR (home-assistant/core#168051, reviewed by @joostlek and @erwindouna). The goal is twofold: give existing users a more robust integration now, and make future copy-paste of platform PRs back to core painless.

Changes are structured as 13 small, reviewable commits so each pattern can be audited on its own.

## ⚠️ Breaking changes

Users will need to **remove and re-add** the integration after updating.

1. **One config entry per account, not per pool.** All pools under the account are auto-discovered. The entry `unique_id` switches from `pool_id` to `username.lower()`.
2. **Entity `unique_id` suffixes switch from human-readable names to translation keys** (e.g. `pool_id-Temperature` → `pool_id-temperature`, `pool_id-Hidro Flow Status` → `pool_id-hidro_flow_status`). Historical state for existing entities will orphan.
3. **Removed sensors**: `pool_name` (redundant with device name) and `city` / `street` / `zipcode` / `country` / `latitude` / `longitude` (static data, no automation value). Lat/lng remain in the `device_tracker` entity; the rest is still in diagnostics output.

Manifest version bumped to **2.0.0** to flag the break.

## What's in each commit

| # | Commit | What it does |
|---|--------|--------------|
| 1 | Hub pattern refactor | `AquariteData` runtime_data with `auth`, `api`, `coordinators` dict; shared token-refresh + health-check loops in `__init__.py`; single-step config flow; race-free subscription shutdown lock |
| 2 | Entity base simplification | `AquariteEntity` now takes only the coordinator — removes ~85 lines of pool_id/pool_name plumbing across 9 platforms |
| 3 | Entity descriptions for all platforms | One entity class per platform driven by frozen `*EntityDescription` tuples; `value_fn(coordinator)` for sensors, `value_path` for writes, `exists_fn` for conditional creation |
| 4 | Boolean coercion | `coordinator.get_bool()` helper uses `bool(int(x or 0))` so string `"0"` doesn't read as `True` |
| 5 | Translated exceptions | Write-path errors raise `HomeAssistantError` with `translation_domain` + `translation_key="communication_error"` so users see localised messages |
| 6 | Options flow removed | Health-check interval is now a hard-coded constant (rolled into commit 1) |
| 7 | Removed redundant sensors | `pool_name` + 6 location sensors — see breaking changes |
| 8 | Callbacks and units | `AddConfigEntryEntitiesCallback`; `UnitOfTime.HOURS`, `UnitOfElectricPotential.MILLIVOLT`; `"g/h"` not `"gr/h"`; `SensorDeviceClass.DURATION` on intel time |
| 9 | Narrowed exception handling | Setup catches `AuthenticationError` → `ConfigEntryAuthFailed` and `AquariteError` → `ConfigEntryNotReady`; write paths catch `AquariteError` only; background loops keep broad catch with `# noqa: BLE001` |
| 10 | Translations cleanup | `data_description` for every field, common-key refs for `invalid_auth` / `unknown` / `already_configured_account`, alphabetised, stale keys removed from en/nl/da |
| 11 | Manifest cleanup | 2-space indent, `integration_type: "hub"`, version 2.0.0 |
| 12 | Light reconciliation | Already compliant with the core review (`ColorMode.ONOFF`, safe bool coercion); verified only |
| 13 | Ruff | `ruff check --fix` + `ruff format` across the package |

## Preserved from the custom component

- `sync_pool_time` service (stripped from the core PR, but useful for custom-component users)
- `reauth` and `reconfigure` flows (useful even without core-level gating)
- Light entity's optimistic state reconciliation with timeout — unique to this integration

## Test plan

- [ ] Fresh install: add integration → credentials prompt only → all pools appear under one entry
- [ ] Multi-pool account: verify every pool gets its own device and full set of entities
- [ ] Token refresh: observe `Aquarite token refresh` task behaviour near expiry; confirm all pools stay subscribed
- [ ] Health check: force a network blip and confirm all pools resubscribe
- [ ] Reauth flow: invalidate credentials, confirm the notification and prompt work
- [ ] Reconfigure flow: change credentials via the entry's Reconfigure button
- [ ] `aquarite.sync_pool_time` service: confirms all loaded pools receive the update
- [ ] Write entities: turn a switch/relay/light on and off; set a pH Low value; change pump mode; set a filtration interval
- [ ] Translation: switch HA to nl/da and confirm entity names + config-flow descriptions render
- [ ] Diagnostics download includes one `pools` block per pool with location data redacted

🤖 Generated with [Claude Code](https://claude.com/claude-code)